### PR TITLE
Aggiunge il calendario scolastico (giorni di chiusura)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -964,6 +964,76 @@ Due bug segnalati dopo l'uso reale di `/admin/maestre`.
       questa modifica non si aggiorna da sola: va rimossa e
       riaggiunta.
 
+## Calendario scolastico: giorni di chiusura (nuovo specs/53)
+- [x] Nuovo requisito `specs/53 - calendario-scolastico.md`: l'admin
+      inserisce/modifica/elimina giorni di chiusura scolastica (intervallo
+      da/a + nota opzionale) su `/admin/calendario`. In un giorno chiuso
+      (registrato dall'admin, oppure sabato/domenica — chiusura implicita,
+      nessun record necessario) non è possibile registrare presenze o
+      pasti, per **nessun ruolo, admin incluso** — a differenza della
+      regola "sola data odierna" di specs/13/14, che esenta l'admin,
+      questo è un vincolo di coerenza dei dati (asilo chiuso = nessuna
+      presenza/pasto da registrare), non un permesso di scrittura. Le
+      pagine Presenze/Pasti mostrano l'informazione (nota, se presente) al
+      posto dei pulsanti. specs/13 e specs/14 aggiornate (sezione Regole)
+      con un rimando incrociato a specs/53, stesso pattern già usato per
+      specs/06 - controllo-consistenza.md (nessuna duplicazione di
+      scenario/test tra i requisiti).
+- [x] `supabase/migrations/0022_calendario_scolastico.sql`: tabella
+      `giorni_chiusura` (intervallo con vincolo `data_fine >= data_inizio`,
+      nota libera), RLS (select per tutto lo staff, insert/update/delete
+      solo admin), funzione `giorno_chiuso(data)` (weekend via
+      `extract(isodow ...)` OR intervallo registrato) e due trigger
+      (`presenze_blocca_se_chiuso`, `pasti_blocca_se_chiuso`) che
+      bloccano insert/update su `presenze`/`pasti` per qualunque ruolo —
+      stesso principio già in vigore per "pasto di un bambino
+      assente/malato" (0012/0017), non un'eccezione per l'admin come
+      invece 0009. Grant a `service_role` incluso da subito (imparato dal
+      bug del report notturno, vedi sopra in questo file).
+- [x] `lib/date.ts:isWeekend` (pura, unit test) + `lib/calendarioScolastico.ts`:
+      `trovaChiusura`/`isGiornoChiuso`/`messaggioChiusura` (pure, unit
+      test in `lib/calendarioScolastico.test.ts`) e `chiusuraPerData`/
+      `assicuraGiornoApribile` (fanno I/O, coperte solo da e2e — stesso
+      criterio di ammissione già in uso per `lib/auth.ts`).
+- [x] `/admin/calendario` (elenco + form di creazione) e
+      `/admin/calendario/[id]` (modifica + eliminazione con conferma,
+      `ConfermaAzione` già esistente) — stesso pattern list+detail già
+      usato per `/admin/bambini/[id]`. Nuove server action in
+      `app/admin/calendario/actions.ts`
+      (`creaGiornoChiusura`/`aggiornaGiornoChiusura`/`eliminaGiornoChiusura`).
+      Link "Calendario scolastico" aggiunto a `NavHeader` per l'admin.
+- [x] `app/dashboard/presenze/[sezioneId]/page.tsx` e
+      `app/dashboard/pasti/[sezioneId]/page.tsx`: caricano il giorno di
+      chiusura per la data corrente, ricalcolano `editable` includendo
+      `!chiuso` (per tutti i ruoli) e passano il messaggio a
+      `PaginaClasseAttivita` (nuovo prop `messaggioChiusura`, banner
+      rosso con priorità sul banner "sola lettura" esistente, che riguarda
+      solo maestra/assistente). Le server action `segnaPresenza`/
+      `segnaPreAsilo`/`segnaPostAsilo`/`salvaNotaPresenza`/`segnaPasto`/
+      `salvaNotaPasto` chiamano `assicuraGiornoApribile` prima di
+      scrivere, per un messaggio d'errore chiaro oltre al trigger DB.
+- [x] Test aggiunti: `lib/date.test.ts` (`isWeekend`),
+      `lib/calendarioScolastico.test.ts` (funzioni pure), nuovo
+      `e2e/53-calendario-scolastico.spec.ts` (un test per ogni
+      `## Scenario:` di specs/53, incluso il controllo axe-core su
+      `/admin/calendario` e sulla scheda di dettaglio). I test che creano
+      un giorno di chiusura usano date lontane nel futuro (per non
+      collidere con "oggi"/"ieri" di altri test) e lo eliminano a fine
+      test (anche in caso di asserzione fallita, via `try`/`finally` nel
+      test che verifica il blocco di Presenze/Pasti).
+- [x] Verificato: `npx tsc --noEmit`, `npx next lint`, `npx vitest run`
+      (131 test) e `npx jscpd` (3 clone preesistenti, sotto soglia,
+      nessuno nuovo) puliti. Suite e2e Playwright non eseguibile da questo
+      ambiente sandbox (nessun dev server né credenziali Supabase — stesso
+      limite di sempre, vedi note precedenti in questo file): da
+      verificare con `npx playwright test e2e/53-calendario-scolastico.spec.ts`
+      (e le altre suite toccate: 13, 14) dal tuo ambiente locale.
+- [ ] **Da fare da parte tua**: applica
+      `supabase/migrations/0022_calendario_scolastico.sql` nel SQL Editor
+      di Supabase (test e produzione) prima di usare `/admin/calendario`
+      — senza, la tabella `giorni_chiusura` non esiste e la pagina fallisce
+      nel caricare l'elenco.
+
 ## Backlog — Fase 2/3
 - [ ] Rette mensili e stato pagamento
 - [ ] Portale genitori (UI dedicata)

--- a/app/admin/calendario/[id]/page.tsx
+++ b/app/admin/calendario/[id]/page.tsx
@@ -1,0 +1,75 @@
+import { redirect } from 'next/navigation';
+import { NavHeader } from '@/components/NavHeader';
+import { FormConEsito } from '@/components/FormConEsito';
+import { PulsanteInvio } from '@/components/PulsanteInvio';
+import { ConfermaAzione } from '@/components/ConfermaAzione';
+import { requireAdmin } from '@/lib/auth';
+import { aggiornaGiornoChiusura, eliminaGiornoChiusura } from '../actions';
+
+export const dynamic = 'force-dynamic';
+
+export default async function GiornoChiusuraDettaglioPage({ params }: { params: { id: string } }) {
+  const { supabase, user, profilo } = await requireAdmin();
+
+  const { data: giorno } = await supabase
+    .from('giorni_chiusura')
+    .select('id, data_inizio, data_fine, nota')
+    .eq('id', params.id)
+    .maybeSingle();
+
+  if (!giorno) redirect('/admin/calendario');
+
+  return (
+    <>
+      <NavHeader nome={profilo?.nome || user.email || ''} ruolo={profilo?.ruolo ?? null} />
+      <main className="mx-auto max-w-2xl space-y-6 px-4 py-8">
+        <a href="/admin/calendario" className="text-sm text-stone-600 hover:text-stone-900">
+          ← Torna al calendario scolastico
+        </a>
+
+        <h1 className="text-lg font-medium">Modifica giorno di chiusura</h1>
+
+        <FormConEsito
+          action={aggiornaGiornoChiusura}
+          className="space-y-2 rounded-xl border border-stone-200 bg-white p-4 shadow-sm"
+        >
+          <input type="hidden" name="giorno_id" value={giorno.id} />
+          <div className="flex flex-wrap gap-2">
+            <input
+              name="data_inizio"
+              type="date"
+              required
+              defaultValue={giorno.data_inizio}
+              aria-label="Data di inizio"
+              className="flex-1 rounded-lg border border-stone-300 px-3 py-2 text-sm outline-none focus:border-stone-500"
+            />
+            <input
+              name="data_fine"
+              type="date"
+              required
+              defaultValue={giorno.data_fine}
+              aria-label="Data di fine"
+              className="flex-1 rounded-lg border border-stone-300 px-3 py-2 text-sm outline-none focus:border-stone-500"
+            />
+          </div>
+          <input
+            name="nota"
+            defaultValue={giorno.nota ?? ''}
+            placeholder="Nota (opzionale, es. Vacanze di Natale)"
+            className="w-full rounded-lg border border-stone-300 px-3 py-2 text-sm outline-none focus:border-stone-500"
+          />
+          <PulsanteInvio className="rounded-lg bg-emerald-700 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-800">
+            Salva modifiche
+          </PulsanteInvio>
+        </FormConEsito>
+
+        <ConfermaAzione
+          azione={eliminaGiornoChiusura}
+          campiNascosti={{ giorno_id: giorno.id }}
+          etichetta="Elimina giorno di chiusura"
+          messaggioConferma="Confermi l'eliminazione?"
+        />
+      </main>
+    </>
+  );
+}

--- a/app/admin/calendario/actions.ts
+++ b/app/admin/calendario/actions.ts
@@ -1,0 +1,79 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { requireAdmin } from '@/lib/auth';
+import type { EsitoAzione } from '@/components/FormConEsito';
+
+// Campi condivisi da creazione e modifica di un giorno di chiusura
+// (specs/53 - calendario-scolastico.md).
+function campiGiornoChiusura(formData: FormData) {
+  return {
+    dataInizio: (formData.get('data_inizio') as string) || '',
+    dataFine: (formData.get('data_fine') as string) || '',
+    nota: ((formData.get('nota') as string) || '').trim() || null,
+  };
+}
+
+export async function creaGiornoChiusura(_stato: EsitoAzione, formData: FormData): Promise<EsitoAzione> {
+  const { supabase } = await requireAdmin();
+  const { dataInizio, dataFine, nota } = campiGiornoChiusura(formData);
+
+  if (!dataInizio || !dataFine) {
+    return { ok: false, messaggio: 'Inserisci sia la data di inizio sia la data di fine.' };
+  }
+  if (dataFine < dataInizio) {
+    return { ok: false, messaggio: 'La data di fine non può precedere la data di inizio.' };
+  }
+
+  const { error } = await supabase
+    .from('giorni_chiusura')
+    .insert({ data_inizio: dataInizio, data_fine: dataFine, nota });
+  if (error) {
+    return { ok: false, messaggio: 'Impossibile creare il giorno di chiusura.', dettaglio: error.message };
+  }
+
+  revalidatePath('/admin/calendario');
+  return { ok: true };
+}
+
+// specs/53 - calendario-scolastico.md, scenario "modificare un giorno di chiusura".
+export async function aggiornaGiornoChiusura(_stato: EsitoAzione, formData: FormData): Promise<EsitoAzione> {
+  const { supabase } = await requireAdmin();
+  const giornoId = formData.get('giorno_id') as string;
+  const { dataInizio, dataFine, nota } = campiGiornoChiusura(formData);
+
+  if (!giornoId || !dataInizio || !dataFine) {
+    return { ok: false, messaggio: 'Inserisci sia la data di inizio sia la data di fine.' };
+  }
+  if (dataFine < dataInizio) {
+    return { ok: false, messaggio: 'La data di fine non può precedere la data di inizio.' };
+  }
+
+  const { error } = await supabase
+    .from('giorni_chiusura')
+    .update({ data_inizio: dataInizio, data_fine: dataFine, nota })
+    .eq('id', giornoId);
+  if (error) {
+    return { ok: false, messaggio: 'Impossibile aggiornare il giorno di chiusura.', dettaglio: error.message };
+  }
+
+  revalidatePath(`/admin/calendario/${giornoId}`);
+  revalidatePath('/admin/calendario');
+  return { ok: true };
+}
+
+// specs/53 - calendario-scolastico.md, scenario "eliminare un giorno di chiusura".
+export async function eliminaGiornoChiusura(_stato: EsitoAzione, formData: FormData): Promise<EsitoAzione> {
+  const { supabase } = await requireAdmin();
+  const giornoId = formData.get('giorno_id') as string;
+  if (!giornoId) return { ok: false, messaggio: 'Giorno di chiusura non valido.' };
+
+  const { error } = await supabase.from('giorni_chiusura').delete().eq('id', giornoId);
+  if (error) {
+    return { ok: false, messaggio: 'Impossibile eliminare il giorno di chiusura.', dettaglio: error.message };
+  }
+
+  revalidatePath('/admin/calendario');
+  redirect('/admin/calendario');
+}

--- a/app/admin/calendario/page.tsx
+++ b/app/admin/calendario/page.tsx
@@ -1,0 +1,84 @@
+import Link from 'next/link';
+import { NavHeader } from '@/components/NavHeader';
+import { FormConEsito } from '@/components/FormConEsito';
+import { PulsanteInvio } from '@/components/PulsanteInvio';
+import { requireAdmin } from '@/lib/auth';
+import { formattaIntervalloItaliano } from '@/lib/date';
+import { creaGiornoChiusura } from './actions';
+
+export const dynamic = 'force-dynamic';
+
+export default async function CalendarioScolasticoPage() {
+  const { supabase, user, profilo } = await requireAdmin();
+
+  const { data: giorniChiusura } = await supabase
+    .from('giorni_chiusura')
+    .select('id, data_inizio, data_fine, nota')
+    .order('data_inizio', { ascending: false });
+
+  return (
+    <>
+      <NavHeader nome={profilo?.nome || user.email || ''} ruolo={profilo?.ruolo ?? null} />
+      <main className="mx-auto max-w-2xl space-y-6 px-4 py-8">
+        <div>
+          <h1 className="text-lg font-medium">Calendario scolastico</h1>
+          <p className="mt-1 text-sm text-stone-600">
+            Giorni di chiusura dell&apos;asilo (vacanze, ponti, chiusure straordinarie). Sabato e
+            domenica sono chiusi sempre, non serve inserirli qui.
+          </p>
+        </div>
+
+        <FormConEsito
+          action={creaGiornoChiusura}
+          resetSuOk
+          className="space-y-2 rounded-xl border border-stone-200 bg-white p-4 shadow-sm"
+        >
+          <div className="flex flex-wrap gap-2">
+            <input
+              name="data_inizio"
+              type="date"
+              required
+              aria-label="Data di inizio"
+              className="flex-1 rounded-lg border border-stone-300 px-3 py-2 text-sm outline-none focus:border-stone-500"
+            />
+            <input
+              name="data_fine"
+              type="date"
+              required
+              aria-label="Data di fine"
+              className="flex-1 rounded-lg border border-stone-300 px-3 py-2 text-sm outline-none focus:border-stone-500"
+            />
+          </div>
+          <input
+            name="nota"
+            placeholder="Nota (opzionale, es. Vacanze di Natale)"
+            className="w-full rounded-lg border border-stone-300 px-3 py-2 text-sm outline-none focus:border-stone-500"
+          />
+          <PulsanteInvio className="rounded-lg bg-emerald-700 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-800">
+            Aggiungi giorno di chiusura
+          </PulsanteInvio>
+        </FormConEsito>
+
+        <ul className="space-y-2">
+          {giorniChiusura?.map((giorno) => (
+            <li key={giorno.id}>
+              <Link
+                href={`/admin/calendario/${giorno.id}`}
+                className="flex items-center justify-between rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm shadow-sm hover:bg-stone-50"
+              >
+                <span>
+                  {formattaIntervalloItaliano(giorno.data_inizio, giorno.data_fine)}
+                  {giorno.nota && <span className="ml-2 text-stone-600">— {giorno.nota}</span>}
+                </span>
+                <span className="text-xs text-stone-500">Modifica</span>
+              </Link>
+            </li>
+          ))}
+          {!giorniChiusura?.length && (
+            <li className="text-sm text-stone-600">Nessun giorno di chiusura ancora inserito.</li>
+          )}
+        </ul>
+      </main>
+    </>
+  );
+}

--- a/app/dashboard/pasti/[sezioneId]/page.tsx
+++ b/app/dashboard/pasti/[sezioneId]/page.tsx
@@ -12,6 +12,7 @@ import { sezionePerId } from '@/lib/sezioni';
 import { classePulsanteStato } from '@/lib/classiStato';
 import { inconsistenzeGiorno, type StatoPasto, type StatoPresenza } from '@/lib/consistenza';
 import { formattaDataOraItaliana } from '@/lib/date';
+import { chiusuraPerData, isGiornoChiuso, messaggioChiusura as calcolaMessaggioChiusura } from '@/lib/calendarioScolastico';
 import { segnaPasto, salvaNotaPasto } from '../actions';
 
 export const dynamic = 'force-dynamic';
@@ -41,7 +42,7 @@ export default async function PastiClassePage({
   const bambini = bambiniSezione ?? [];
   const idBambini = bambini.map((b) => b.id);
 
-  const [{ data: pastiData }, { data: presenzeData }, { data: comunicazione }] = await Promise.all([
+  const [{ data: pastiData }, { data: presenzeData }, { data: comunicazione }, chiusura] = await Promise.all([
     idBambini.length
       ? supabase.from('pasti').select('bambino_id, mangiato, note').eq('data', data).in('bambino_id', idBambini)
       : Promise.resolve({ data: [] as { bambino_id: string; mangiato: string; note: string | null }[] }),
@@ -53,11 +54,18 @@ export default async function PastiClassePage({
       .select('numero_pasti, comunicato_at, comunicato_da_nome')
       .eq('data', data)
       .maybeSingle(),
+    chiusuraPerData(supabase, data),
   ]);
 
   const pastoPerBambino = new Map((pastiData ?? []).map((p) => [p.bambino_id, p]));
   const presenzaPerBambino = new Map((presenzeData ?? []).map((p) => [p.bambino_id, p.stato]));
-  const editable = puoScrivereData(ruolo, data);
+
+  const chiusure = chiusura ? [chiusura] : [];
+  const chiuso = isGiornoChiuso(data, chiusure);
+  const messaggioChiuso = calcolaMessaggioChiusura(data, chiusure);
+  // Un giorno di chiusura scolastica non è scrivibile da nessuno, admin
+  // incluso (specs/53 - calendario-scolastico.md).
+  const editable = puoScrivereData(ruolo, data) && !chiuso;
   // La comunicazione a Rojac è per l'intero asilo (specs/16 -
   // comunicazione-pasti-rojac.md), non per questa sola classe: blocca
   // comunque la maestra qui, come in ogni altra classe. L'admin può
@@ -79,6 +87,7 @@ export default async function PastiClassePage({
       basePath={`/dashboard/pasti/${sezioneId}`}
       data={data}
       editable={editable}
+      messaggioChiusura={messaggioChiuso}
       vuoto={!bambini.length}
       riepilogo={
         bambini.length > 0 && (

--- a/app/dashboard/pasti/actions.ts
+++ b/app/dashboard/pasti/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { requireProfilo, assicuraScrivibile, assicuraAccessoPasti, puoScrivereData } from '@/lib/auth';
+import { assicuraGiornoApribile } from '@/lib/calendarioScolastico';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { contaPastiSiOggiTuttoAsilo } from '@/lib/pastiRojac';
 import { inviaEmail } from '@/lib/email';
@@ -52,6 +53,7 @@ export async function segnaPasto(
   const { supabase, user, profilo } = await requireProfilo();
   assicuraAccessoPasti(profilo?.ruolo);
   assicuraScrivibile(profilo?.ruolo, data);
+  await assicuraGiornoApribile(supabase, data);
   await assicuraNonAssente(supabase, bambinoId, data);
 
   const note = (formData.get('nota_pasto') as string)?.trim() || null;
@@ -73,6 +75,7 @@ export async function salvaNotaPasto(
   const { supabase, user, profilo } = await requireProfilo();
   assicuraAccessoPasti(profilo?.ruolo);
   assicuraScrivibile(profilo?.ruolo, data);
+  await assicuraGiornoApribile(supabase, data);
 
   if (!mangiatoAttuale) {
     throw new Error('Segna prima uno stato pasto per poter salvare una nota.');

--- a/app/dashboard/presenze/[sezioneId]/page.tsx
+++ b/app/dashboard/presenze/[sezioneId]/page.tsx
@@ -11,6 +11,7 @@ import { sezionePerId } from '@/lib/sezioni';
 import { classePulsanteStato, classePulsanteToggle } from '@/lib/classiStato';
 import type { RigaPresenza } from '@/lib/presenza';
 import { inconsistenzeGiorno, type StatoPasto, type StatoPresenza } from '@/lib/consistenza';
+import { chiusuraPerData, isGiornoChiuso, messaggioChiusura as calcolaMessaggioChiusura } from '@/lib/calendarioScolastico';
 import { segnaPresenza, segnaPreAsilo, segnaPostAsilo, salvaNotaPresenza } from '../actions';
 
 export const dynamic = 'force-dynamic';
@@ -67,7 +68,15 @@ export default async function PresenzeClassePage({
 
   const presenzaPerBambino = new Map((presenzeData ?? []).map((p) => [p.bambino_id, p]));
   const pastoPerBambino = new Map((pastiData ?? []).map((p) => [p.bambino_id, p.mangiato]));
-  const editable = puoScrivereData(ruolo, data);
+
+  const chiusura = await chiusuraPerData(supabase, data);
+  const chiusure = chiusura ? [chiusura] : [];
+  const chiuso = isGiornoChiuso(data, chiusure);
+  const messaggioChiuso = calcolaMessaggioChiusura(data, chiusure);
+  // Un giorno di chiusura scolastica non è scrivibile da nessuno, admin
+  // incluso (specs/53 - calendario-scolastico.md, a differenza della
+  // regola "sola data odierna" sotto, che esenta l'admin).
+  const editable = puoScrivereData(ruolo, data) && !chiuso;
   const numeroPresenti = bambini.filter((b) => presenzaPerBambino.get(b.id)?.stato === 'presente').length;
   const numeroPreAsilo = bambini.filter((b) => presenzaPerBambino.get(b.id)?.pre_asilo).length;
   const numeroPostAsilo = bambini.filter((b) => presenzaPerBambino.get(b.id)?.post_asilo).length;
@@ -81,6 +90,7 @@ export default async function PresenzeClassePage({
       basePath={`/dashboard/presenze/${sezioneId}`}
       data={data}
       editable={editable}
+      messaggioChiusura={messaggioChiuso}
       vuoto={!bambini.length}
       riepilogo={
         bambini.length > 0 && (

--- a/app/dashboard/presenze/actions.ts
+++ b/app/dashboard/presenze/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { requireProfilo, assicuraScrivibile } from '@/lib/auth';
+import { assicuraGiornoApribile } from '@/lib/calendarioScolastico';
 import { prossimaPresenza, type AzionePresenza, type RigaPresenza } from '@/lib/presenza';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
@@ -43,6 +44,7 @@ async function applicaAzionePresenza(
 ) {
   const { supabase, user, profilo } = await requireProfilo();
   assicuraScrivibile(profilo?.ruolo, data);
+  await assicuraGiornoApribile(supabase, data);
 
   const note = (formData.get('nota_presenza') as string)?.trim() || null;
   const prossima = prossimaPresenza(rigaAttuale, azione);
@@ -101,6 +103,7 @@ export async function salvaNotaPresenza(
 ) {
   const { supabase, user, profilo } = await requireProfilo();
   assicuraScrivibile(profilo?.ruolo, data);
+  await assicuraGiornoApribile(supabase, data);
 
   if (!rigaAttuale) {
     throw new Error('Segna prima uno stato di presenza per poter salvare una nota.');

--- a/components/NavHeader.tsx
+++ b/components/NavHeader.tsx
@@ -27,6 +27,9 @@ export function NavHeader({
               <Link href="/admin/maestre" className="text-sm text-stone-600 hover:text-emerald-700">
                 Utenti
               </Link>
+              <Link href="/admin/calendario" className="text-sm text-stone-600 hover:text-emerald-700">
+                Calendario scolastico
+              </Link>
             </>
           )}
         </div>

--- a/components/PaginaClasseAttivita.tsx
+++ b/components/PaginaClasseAttivita.tsx
@@ -15,6 +15,7 @@ export function PaginaClasseAttivita({
   basePath,
   data,
   editable,
+  messaggioChiusura,
   vuoto,
   riepilogo,
   children,
@@ -26,6 +27,11 @@ export function PaginaClasseAttivita({
   basePath: string;
   data: string;
   editable: boolean;
+  // Messaggio di chiusura scolastica (specs/53 - calendario-scolastico.md)
+  // per la data corrente, o null se scrivibile. Ha priorità sul banner
+  // "sola lettura" sotto: vale per QUALUNQUE ruolo, admin incluso, a
+  // differenza di quel banner (che riguarda solo maestra/assistente).
+  messaggioChiusura?: string | null;
   vuoto: boolean;
   riepilogo?: ReactNode;
   children: ReactNode;
@@ -45,10 +51,16 @@ export function PaginaClasseAttivita({
 
         {riepilogo}
 
-        {!editable && (
-          <p className="rounded-xl border border-stone-300 bg-stone-50 p-3 text-sm text-stone-600">
-            Sola lettura: puoi modificare solo la data di oggi.
+        {messaggioChiusura ? (
+          <p className="rounded-xl border border-rose-300 bg-rose-50 p-3 text-sm text-rose-800">
+            🔒 {messaggioChiusura}
           </p>
+        ) : (
+          !editable && (
+            <p className="rounded-xl border border-stone-300 bg-stone-50 p-3 text-sm text-stone-600">
+              Sola lettura: puoi modificare solo la data di oggi.
+            </p>
+          )
         )}
 
         {vuoto && <p className="text-sm text-stone-600">Nessun bambino in questa classe.</p>}

--- a/e2e/53-calendario-scolastico.spec.ts
+++ b/e2e/53-calendario-scolastico.spec.ts
@@ -1,0 +1,238 @@
+// Requisito: specs/53 - calendario-scolastico.md
+//
+// ATTENZIONE: questi test scrivono davvero in `giorni_chiusura` sul
+// progetto Supabase di test — vedi la nota in 13-segna-presenza.spec.ts.
+// I test che creano un giorno di chiusura usano una data lontana nel
+// futuro (dataFraGiorni con un n grande) per non collidere con "oggi"/
+// "ieri", usate da altri test, e lo eliminano a fine test.
+import { test, expect, type Page } from '@playwright/test';
+import {
+  dataFraGiorni,
+  dataProssimoGiornoFeriale,
+  dataProssimoSabato,
+  hasCredenziali,
+  nessunaViolazioneA11yGrave,
+  statoAutenticazione,
+} from './helpers';
+
+async function apriPrimaClassePresenze(page: Page, data: string): Promise<boolean> {
+  await page.goto(`/dashboard/presenze?data=${data}`);
+  const primaClasse = page.locator('a.bg-emerald-50').first();
+  if ((await primaClasse.count()) === 0) return false;
+  await primaClasse.click();
+  await page.waitForURL(/\/dashboard\/presenze\/.+/);
+  return true;
+}
+
+async function apriPrimaClassePasti(page: Page, data: string): Promise<boolean> {
+  await page.goto(`/dashboard/pasti?data=${data}`);
+  const primaClasse = page.locator('a.bg-emerald-50').first();
+  if ((await primaClasse.count()) === 0) return false;
+  await primaClasse.click();
+  await page.waitForURL(/\/dashboard\/pasti\/.+/);
+  return true;
+}
+
+test.describe('53 — Calendario scolastico', () => {
+  test.describe('come admin', () => {
+    test.use({ storageState: statoAutenticazione('admin') });
+
+    test.beforeEach(async ({ page }) => {
+      test.skip(!hasCredenziali('admin'), 'richiede E2E_ADMIN_EMAIL/PASSWORD');
+    });
+
+    test('/admin/calendario: elementi presenti + accessibilità', async ({ page }) => {
+      await page.goto('/admin/calendario');
+      await expect(page.getByRole('heading', { name: 'Calendario scolastico' })).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Aggiungi giorno di chiusura' })).toBeVisible();
+      await nessunaViolazioneA11yGrave(page);
+    });
+
+    test('creare un giorno di chiusura con nota lo mostra in elenco', async ({ page }) => {
+      const inizio = dataFraGiorni(300);
+      const fine = dataFraGiorni(305);
+      const nota = `Nota E2E ${Date.now()}`;
+
+      await page.goto('/admin/calendario');
+      await page.getByLabel('Data di inizio').fill(inizio);
+      await page.getByLabel('Data di fine').fill(fine);
+      await page.getByPlaceholder('Nota (opzionale, es. Vacanze di Natale)').fill(nota);
+      await page.getByRole('button', { name: 'Aggiungi giorno di chiusura' }).click();
+
+      const riga = page.getByText(nota, { exact: false });
+      await expect(riga).toBeVisible({ timeout: 20_000 });
+
+      // Pulizia: elimino il giorno appena creato per non lasciare uno
+      // stato che blocchi permanentemente quella data per altri test.
+      await riga.click();
+      await page.waitForURL(/\/admin\/calendario\/.+/);
+      await page.getByRole('button', { name: 'Elimina giorno di chiusura' }).click();
+      await page.getByRole('button', { name: 'Sì' }).click();
+      await page.waitForURL('/admin/calendario');
+    });
+
+    test('un solo giorno di chiusura (data di inizio = data di fine)', async ({ page }) => {
+      const giorno = dataFraGiorni(310);
+      const nota = `Ponte E2E ${Date.now()}`;
+
+      await page.goto('/admin/calendario');
+      await page.getByLabel('Data di inizio').fill(giorno);
+      await page.getByLabel('Data di fine').fill(giorno);
+      await page.getByPlaceholder('Nota (opzionale, es. Vacanze di Natale)').fill(nota);
+      await page.getByRole('button', { name: 'Aggiungi giorno di chiusura' }).click();
+
+      const riga = page.getByText(nota, { exact: false });
+      await expect(riga).toBeVisible({ timeout: 20_000 });
+
+      // Pulizia.
+      await riga.click();
+      await page.waitForURL(/\/admin\/calendario\/.+/);
+      await page.getByRole('button', { name: 'Elimina giorno di chiusura' }).click();
+      await page.getByRole('button', { name: 'Sì' }).click();
+    });
+
+    test('la data di fine non può precedere quella di inizio', async ({ page }) => {
+      const inizio = dataFraGiorni(320);
+      const fine = dataFraGiorni(315);
+
+      await page.goto('/admin/calendario');
+      await page.getByLabel('Data di inizio').fill(inizio);
+      await page.getByLabel('Data di fine').fill(fine);
+      await page.getByRole('button', { name: 'Aggiungi giorno di chiusura' }).click();
+
+      await expect(page.getByRole('alert')).toContainText('non può precedere');
+      await expect(page.getByText('Nessun giorno di chiusura ancora inserito.')).toBeVisible();
+    });
+
+    test('modificare un giorno di chiusura', async ({ page }) => {
+      const inizio = dataFraGiorni(330);
+      const fine = dataFraGiorni(332);
+      const notaIniziale = `Modifica E2E ${Date.now()}`;
+
+      await page.goto('/admin/calendario');
+      await page.getByLabel('Data di inizio').fill(inizio);
+      await page.getByLabel('Data di fine').fill(fine);
+      await page.getByPlaceholder('Nota (opzionale, es. Vacanze di Natale)').fill(notaIniziale);
+      await page.getByRole('button', { name: 'Aggiungi giorno di chiusura' }).click();
+
+      const riga = page.getByText(notaIniziale, { exact: false });
+      await expect(riga).toBeVisible({ timeout: 20_000 });
+      await riga.click();
+      await page.waitForURL(/\/admin\/calendario\/.+/);
+      await nessunaViolazioneA11yGrave(page);
+
+      const notaModificata = `${notaIniziale} - aggiornata`;
+      await page.getByPlaceholder('Nota (opzionale, es. Vacanze di Natale)').fill(notaModificata);
+      await page.getByRole('button', { name: 'Salva modifiche' }).click();
+
+      await expect(page.getByPlaceholder('Nota (opzionale, es. Vacanze di Natale)')).toHaveValue(
+        notaModificata,
+        { timeout: 20_000 }
+      );
+
+      // Resta salvato anche dopo un ricaricamento.
+      await page.reload();
+      await expect(page.getByPlaceholder('Nota (opzionale, es. Vacanze di Natale)')).toHaveValue(
+        notaModificata
+      );
+
+      // Pulizia.
+      await page.getByRole('button', { name: 'Elimina giorno di chiusura' }).click();
+      await page.getByRole('button', { name: 'Sì' }).click();
+    });
+
+    test('eliminare un giorno di chiusura lo rimuove dall\'elenco', async ({ page }) => {
+      const inizio = dataFraGiorni(340);
+      const fine = dataFraGiorni(340);
+      const nota = `Elimina E2E ${Date.now()}`;
+
+      await page.goto('/admin/calendario');
+      await page.getByLabel('Data di inizio').fill(inizio);
+      await page.getByLabel('Data di fine').fill(fine);
+      await page.getByPlaceholder('Nota (opzionale, es. Vacanze di Natale)').fill(nota);
+      await page.getByRole('button', { name: 'Aggiungi giorno di chiusura' }).click();
+
+      const riga = page.getByText(nota, { exact: false });
+      await expect(riga).toBeVisible({ timeout: 20_000 });
+      await riga.click();
+      await page.waitForURL(/\/admin\/calendario\/.+/);
+
+      await page.getByRole('button', { name: 'Elimina giorno di chiusura' }).click();
+      await page.getByRole('button', { name: 'Sì' }).click();
+      await page.waitForURL('/admin/calendario');
+
+      await expect(page.getByText(nota, { exact: false })).toHaveCount(0);
+    });
+
+    test('un giorno di chiusura registrato blocca Presenze e Pasti, anche per l\'admin', async ({
+      page,
+    }) => {
+      const giorno = dataFraGiorni(350);
+      const nota = `Chiusura E2E ${Date.now()}`;
+
+      await page.goto('/admin/calendario');
+      await page.getByLabel('Data di inizio').fill(giorno);
+      await page.getByLabel('Data di fine').fill(giorno);
+      await page.getByPlaceholder('Nota (opzionale, es. Vacanze di Natale)').fill(nota);
+      await page.getByRole('button', { name: 'Aggiungi giorno di chiusura' }).click();
+      await expect(page.getByText(nota, { exact: false })).toBeVisible({ timeout: 20_000 });
+
+      try {
+        const haClassiPresenze = await apriPrimaClassePresenze(page, giorno);
+        if (haClassiPresenze) {
+          await expect(page.getByText(nota, { exact: false })).toBeVisible();
+          await expect(page.getByRole('button', { name: 'Presente' })).toHaveCount(0);
+          await expect(page.getByRole('button', { name: 'Assente' })).toHaveCount(0);
+        }
+
+        const haClassiPasti = await apriPrimaClassePasti(page, giorno);
+        if (haClassiPasti) {
+          await expect(page.getByText(nota, { exact: false })).toBeVisible();
+          await expect(page.getByRole('button', { name: 'Sì', exact: true })).toHaveCount(0);
+        }
+      } finally {
+        // Pulizia, anche se un'asserzione sopra fallisce.
+        await page.goto('/admin/calendario');
+        await page.getByText(nota, { exact: false }).click();
+        await page.waitForURL(/\/admin\/calendario\/.+/);
+        await page.getByRole('button', { name: 'Elimina giorno di chiusura' }).click();
+        await page.getByRole('button', { name: 'Sì' }).click();
+      }
+    });
+
+    test('un sabato è chiusura implicita anche senza un giorno registrato', async ({ page }) => {
+      const sabato = dataProssimoSabato();
+      const haClassi = await apriPrimaClassePresenze(page, sabato);
+      test.skip(!haClassi, 'nessuna classe attiva per questo account');
+
+      await expect(page.getByText("L'asilo è chiuso", { exact: false })).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Presente' })).toHaveCount(0);
+    });
+  });
+
+  test.describe('come maestra', () => {
+    test.use({ storageState: statoAutenticazione('maestra') });
+
+    test.beforeEach(async ({ page }) => {
+      test.skip(!hasCredenziali('maestra'), 'richiede E2E_MAESTRA_EMAIL/PASSWORD');
+    });
+
+    test('un sabato mostra la chiusura anche alla maestra, senza pulsanti', async ({ page }) => {
+      const sabato = dataProssimoSabato();
+      const haClassi = await apriPrimaClassePresenze(page, sabato);
+      test.skip(!haClassi, 'nessuna classe attiva per questo account');
+
+      await expect(page.getByText("L'asilo è chiuso", { exact: false })).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Presente' })).toHaveCount(0);
+      await expect(page.getByRole('button', { name: 'Assente' })).toHaveCount(0);
+    });
+
+    test('un giorno feriale resta scrivibile (nessun falso positivo di chiusura)', async ({ page }) => {
+      const haClassi = await apriPrimaClassePresenze(page, dataProssimoGiornoFeriale());
+      test.skip(!haClassi, 'nessuna classe attiva per questo account');
+
+      await expect(page.getByText("L'asilo è chiuso", { exact: false })).toHaveCount(0);
+      await expect(page.getByText('Giorno di chiusura scolastica', { exact: false })).toHaveCount(0);
+    });
+  });
+});

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -21,6 +21,41 @@ export function dataIeriRoma(): string {
   return d.toISOString().slice(0, 10);
 }
 
+// Oggi + n giorni (fuso Europe/Rome, n può essere negativo) — usata dai
+// test di specs/53 - calendario-scolastico.md per trovare un prossimo
+// sabato/domenica e una data lontana su cui creare un giorno di chiusura
+// di prova senza collidere con "oggi"/"ieri", usate da altri test.
+export function dataFraGiorni(giorni: number): string {
+  const [anno, mese, giorno] = dataOggiRoma().split('-').map(Number);
+  const d = new Date(Date.UTC(anno, mese - 1, giorno + giorni, 12));
+  return d.toISOString().slice(0, 10);
+}
+
+// Il prossimo sabato, oggi compreso se oggi stesso è sabato (specs/53,
+// scenario "sabato e domenica sono chiusura implicita").
+export function dataProssimoSabato(): string {
+  for (let i = 0; i < 7; i++) {
+    const candidata = dataFraGiorni(i);
+    const [anno, mese, giorno] = candidata.split('-').map(Number);
+    if (new Date(Date.UTC(anno, mese - 1, giorno, 12)).getUTCDay() === 6) return candidata;
+  }
+  throw new Error('impossibile trovare un sabato entro 7 giorni');
+}
+
+// Il prossimo giorno feriale (lun-ven), oggi compreso se oggi stesso lo
+// è già — usata dai test che devono verificare "nessuna chiusura" su un
+// giorno qualunque senza dipendere da che giorno della settimana sia
+// "oggi" quando la suite viene eseguita (specs/53).
+export function dataProssimoGiornoFeriale(): string {
+  for (let i = 0; i < 7; i++) {
+    const candidata = dataFraGiorni(i);
+    const [anno, mese, giorno] = candidata.split('-').map(Number);
+    const giornoSettimana = new Date(Date.UTC(anno, mese - 1, giorno, 12)).getUTCDay();
+    if (giornoSettimana !== 0 && giornoSettimana !== 6) return candidata;
+  }
+  throw new Error('impossibile trovare un giorno feriale entro 7 giorni');
+}
+
 // Il form di creazione bambino su /admin (specs/50 - amministrazione_base.md)
 // e i mini-form "assegna rapidamente" (uno per bambino "senza classe")
 // condividono lo stesso name="sezione_id": gli <form> non si annidano

--- a/lib/calendarioScolastico.test.ts
+++ b/lib/calendarioScolastico.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { isGiornoChiuso, messaggioChiusura, trovaChiusura, type GiornoChiusura } from './calendarioScolastico';
+
+const VACANZE_NATALE: GiornoChiusura = {
+  id: '1',
+  dataInizio: '2026-12-23',
+  dataFine: '2027-01-06',
+  nota: 'Vacanze di Natale',
+};
+const PONTE_SENZA_NOTA: GiornoChiusura = {
+  id: '2',
+  dataInizio: '2026-11-02',
+  dataFine: '2026-11-02',
+  nota: null,
+};
+
+describe('trovaChiusura', () => {
+  it('trova la chiusura che copre la data', () => {
+    expect(trovaChiusura('2026-12-25', [VACANZE_NATALE])).toEqual(VACANZE_NATALE);
+  });
+
+  it('include gli estremi dell\'intervallo', () => {
+    expect(trovaChiusura('2026-12-23', [VACANZE_NATALE])).toEqual(VACANZE_NATALE);
+    expect(trovaChiusura('2027-01-06', [VACANZE_NATALE])).toEqual(VACANZE_NATALE);
+  });
+
+  it('restituisce null se nessuna chiusura copre la data', () => {
+    expect(trovaChiusura('2026-12-22', [VACANZE_NATALE])).toBeNull();
+    expect(trovaChiusura('2027-01-07', [VACANZE_NATALE])).toBeNull();
+  });
+
+  it('funziona con un intervallo di un solo giorno', () => {
+    expect(trovaChiusura('2026-11-02', [PONTE_SENZA_NOTA])).toEqual(PONTE_SENZA_NOTA);
+    expect(trovaChiusura('2026-11-01', [PONTE_SENZA_NOTA])).toBeNull();
+  });
+
+  it('restituisce null con un elenco vuoto', () => {
+    expect(trovaChiusura('2026-12-25', [])).toBeNull();
+  });
+});
+
+describe('isGiornoChiuso', () => {
+  it('è vero dentro un giorno di chiusura registrato', () => {
+    expect(isGiornoChiuso('2026-12-25', [VACANZE_NATALE])).toBe(true);
+  });
+
+  it('è vero di sabato/domenica anche senza nessuna chiusura registrata', () => {
+    expect(isGiornoChiuso('2026-08-29', [])).toBe(true); // sabato
+    expect(isGiornoChiuso('2026-08-30', [])).toBe(true); // domenica
+  });
+
+  it('è falso un giorno feriale fuori da ogni chiusura', () => {
+    expect(isGiornoChiuso('2026-08-28', [VACANZE_NATALE])).toBe(false);
+  });
+
+  it('un weekend dentro un intervallo di chiusura resta chiuso (nessuna doppia negazione)', () => {
+    // 2026-12-26 è un sabato, comunque dentro VACANZE_NATALE.
+    expect(isGiornoChiuso('2026-12-26', [VACANZE_NATALE])).toBe(true);
+  });
+});
+
+describe('messaggioChiusura', () => {
+  it('mostra la nota quando presente', () => {
+    expect(messaggioChiusura('2026-12-25', [VACANZE_NATALE])).toBe(
+      'Giorno di chiusura scolastica: Vacanze di Natale.'
+    );
+  });
+
+  it('mostra un messaggio generico quando la nota è assente', () => {
+    expect(messaggioChiusura('2026-11-02', [PONTE_SENZA_NOTA])).toBe('Giorno di chiusura scolastica.');
+  });
+
+  it('mostra il messaggio di weekend quando non c\'è una chiusura registrata', () => {
+    expect(messaggioChiusura('2026-08-29', [])).toBe(
+      "L'asilo è chiuso: sabato e domenica non è possibile registrare presenze o pasti."
+    );
+  });
+
+  it('preferisce la chiusura registrata al messaggio di weekend generico se entrambi si applicano', () => {
+    expect(messaggioChiusura('2026-12-26', [VACANZE_NATALE])).toBe(
+      'Giorno di chiusura scolastica: Vacanze di Natale.'
+    );
+  });
+
+  it('restituisce null per un giorno feriale scrivibile', () => {
+    expect(messaggioChiusura('2026-08-28', [VACANZE_NATALE])).toBeNull();
+  });
+});

--- a/lib/calendarioScolastico.ts
+++ b/lib/calendarioScolastico.ts
@@ -1,0 +1,71 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { isWeekend } from '@/lib/date';
+
+export type GiornoChiusura = { id: string; dataInizio: string; dataFine: string; nota: string | null };
+
+// Il giorno di chiusura (registrato dall'admin) che copre `data`, se
+// esiste — funzione pura, nessun I/O: riceve l'elenco già caricato
+// invece di interrogare il database (vedi chiusuraPerData sotto per la
+// query). Non gestisce sovrapposizioni tra più chiusure (specs/53,
+// "Regole": non sono un caso da distinguere, il giorno risulta comunque
+// chiuso) — restituisce la prima che copre la data.
+export function trovaChiusura(data: string, chiusure: GiornoChiusura[]): GiornoChiusura | null {
+  return chiusure.find((c) => data >= c.dataInizio && data <= c.dataFine) ?? null;
+}
+
+// Vero se in `data` l'asilo è chiuso: weekend (specs/53) o dentro un
+// giorno di chiusura registrato dall'admin. Funzione pura, stessa
+// duplice regola implementata lato database in
+// supabase/migrations/0022_calendario_scolastico.sql:giorno_chiuso.
+export function isGiornoChiuso(data: string, chiusure: GiornoChiusura[]): boolean {
+  return isWeekend(data) || trovaChiusura(data, chiusure) !== null;
+}
+
+// Messaggio da mostrare in Presenze/Pasti quando il giorno è chiuso,
+// null se scrivibile (specs/53, scenari "un giorno di chiusura è
+// visibile e bloccante in Presenze/Pasti"). Pura: nessun I/O.
+export function messaggioChiusura(data: string, chiusure: GiornoChiusura[]): string | null {
+  const chiusura = trovaChiusura(data, chiusure);
+  if (chiusura) {
+    return chiusura.nota
+      ? `Giorno di chiusura scolastica: ${chiusura.nota}.`
+      : 'Giorno di chiusura scolastica.';
+  }
+  if (isWeekend(data)) {
+    return "L'asilo è chiuso: sabato e domenica non è possibile registrare presenze o pasti.";
+  }
+  return null;
+}
+
+// Giorni di chiusura registrati dall'admin che coprono `data` (fa I/O,
+// resta coperta solo da e2e — vedi CLAUDE.md, criterio unit test). Una
+// data può ricadere in al più una chiusura in pratica (le sovrapposizioni
+// non sono vietate ma non cambiano il comportamento, specs/53), quindi
+// basta la prima riga trovata.
+export async function chiusuraPerData(supabase: SupabaseClient, data: string): Promise<GiornoChiusura | null> {
+  const { data: riga } = await supabase
+    .from('giorni_chiusura')
+    .select('id, data_inizio, data_fine, nota')
+    .lte('data_inizio', data)
+    .gte('data_fine', data)
+    .limit(1)
+    .maybeSingle();
+
+  if (!riga) return null;
+  return { id: riga.id, dataInizio: riga.data_inizio, dataFine: riga.data_fine, nota: riga.nota };
+}
+
+// Controllo esplicito lato server action, prima di scrivere su
+// presenze/pasti (specs/53 - calendario-scolastico.md): per un messaggio
+// d'errore chiaro, oltre al trigger DB che è la difesa reale (vedi
+// supabase/migrations/0022_calendario_scolastico.sql) — stesso pattern
+// già in uso per assicuraScrivibile (lib/auth.ts) e assicuraNonAssente
+// (app/dashboard/pasti/actions.ts). Vale per QUALUNQUE ruolo, admin
+// incluso: a differenza di assicuraScrivibile, non riceve né controlla
+// il ruolo.
+export async function assicuraGiornoApribile(supabase: SupabaseClient, data: string): Promise<void> {
+  const chiusura = await chiusuraPerData(supabase, data);
+  if (isGiornoChiuso(data, chiusura ? [chiusura] : [])) {
+    throw new Error('Impossibile registrare: è un giorno di chiusura scolastica.');
+  }
+}

--- a/lib/date.test.ts
+++ b/lib/date.test.ts
@@ -9,6 +9,7 @@ import {
   giorniInRange,
   isUltimoGiornoMese,
   isUltimoGiornoSettimana,
+  isWeekend,
   lunediSettimana,
   meseDaData,
   mesePrecedente,
@@ -203,5 +204,24 @@ describe('formattaDataOraItaliana', () => {
 
   it('aggiunge lo zero iniziale a giorno/mese/ora/minuti a una cifra', () => {
     expect(formattaDataOraItaliana('2026-03-05T07:09:00Z')).toBe('05/03/2026_08:09');
+  });
+});
+
+describe('isWeekend', () => {
+  it('riconosce un sabato', () => {
+    expect(isWeekend('2026-08-29')).toBe(true);
+  });
+
+  it('riconosce una domenica', () => {
+    expect(isWeekend('2026-08-30')).toBe(true);
+  });
+
+  it('riconosce un giorno feriale', () => {
+    expect(isWeekend('2026-08-28')).toBe(false);
+  });
+
+  it("riconosce un venerdì e un lunedì come feriali (confini del weekend)", () => {
+    expect(isWeekend('2026-08-28')).toBe(false);
+    expect(isWeekend('2026-08-31')).toBe(false);
   });
 });

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -124,6 +124,16 @@ export function formattaDataOraItaliana(istante: string | Date): string {
   return `${data}_${ora}`;
 }
 
+// Vero se `data` è un sabato o una domenica (specs/53 - calendario-
+// scolastico.md: l'asilo è sempre chiuso in questi giorni, senza bisogno
+// di un giorno di chiusura registrato dall'admin). getUTCDay(): 0 =
+// domenica, 6 = sabato.
+export function isWeekend(data: string): boolean {
+  const [anno, mese, giorno] = data.split('-').map(Number);
+  const giornoSettimana = new Date(Date.UTC(anno, mese - 1, giorno, 12)).getUTCDay();
+  return giornoSettimana === 0 || giornoSettimana === 6;
+}
+
 // Tutte le date da `inizio` a `fine` (incluse), in ordine.
 export function giorniInRange(inizio: string, fine: string): string[] {
   const giorni: string[] = [];

--- a/lib/versione.ts
+++ b/lib/versione.ts
@@ -4,5 +4,5 @@
 // ora, minuti e secondi (fuso Europe/Rome, non UTC — coerente con
 // lib/date.ts), non solo la data: utile per distinguere più rilasci
 // fatti nello stesso giorno.
-export const VERSIONE_APP = '0.11.2';
-export const DATA_BUILD = '2026-08-26 22:24:45';
+export const VERSIONE_APP = '0.12.0';
+export const DATA_BUILD = '2026-08-28 19:40:04';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "girasole",
-  "version": "0.1.0",
+  "version": "0.12.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/specs/00 - overview.md
+++ b/specs/00 - overview.md
@@ -63,6 +63,9 @@ della maestra, `5x` amministrazione.
 - [52 - report-email-automatico.md](52%20-%20report-email-automatico.md) —
   invio automatico notturno dei report (giornaliero/settimanale/mensile)
   in PDF via email
+- [53 - calendario-scolastico.md](53%20-%20calendario-scolastico.md) —
+  giorni di chiusura scolastica (admin) e blocco di presenze/pasti nei
+  giorni chiusi, weekend inclusi
 
 Quando si aggiunge un requisito nuovo che non rientra in nessuno scenario
 esistente, creare un nuovo file numerato in questa cartella (seguendo la

--- a/specs/13 - segna-presenza.md
+++ b/specs/13 - segna-presenza.md
@@ -168,7 +168,10 @@ attivi e posso modificare lo stato di quella data
   solo in UI (vedi
   `supabase/migrations/0009_scrittura_solo_oggi_maestra.sql`); possono
   comunque consultare in sola lettura le altre date.
-- Il ruolo "admin" può scrivere su qualunque data, passata o futura.
+- Il ruolo "admin" può scrivere su qualunque data, passata o futura,
+  **tranne** un giorno di chiusura scolastica (vedi
+  [53 - calendario-scolastico.md](53%20-%20calendario-scolastico.md)):
+  quel blocco non fa eccezioni di ruolo.
 - L'elenco bambini di una classe mostra solo i bambini attivi
   (`bambini.attiva = true`): un bambino disattivato dall'admin non
   compare più qui, pur restando collegate le sue presenze passate (vedi

--- a/specs/14 - segna-pasto.md
+++ b/specs/14 - segna-pasto.md
@@ -108,7 +108,9 @@ alcun dato pasto
   `lib/date.ts`.
 - Il ruolo "maestra" può scrivere solo sulla data odierna, l'admin su
   qualunque data — stessa regola e stesso meccanismo (RLS) di
-  [13 - segna-presenza.md](13%20-%20segna-presenza.md).
+  [13 - segna-presenza.md](13%20-%20segna-presenza.md). **Eccezione
+  valida per entrambi, admin incluso**: un giorno di chiusura scolastica
+  (vedi [53 - calendario-scolastico.md](53%20-%20calendario-scolastico.md)).
 - Presenza e pasto sono indipendenti: si può segnare il pasto anche senza
   aver ancora segnato la presenza (utile se la maestra segna prima il
   pranzo e la presenza a fine giornata) — a meno che la presenza non sia

--- a/specs/53 - calendario-scolastico.md
+++ b/specs/53 - calendario-scolastico.md
@@ -1,0 +1,109 @@
+# 53 — Calendario scolastico (giorni di chiusura)
+
+## Attori
+Admin (gestisce i giorni di chiusura). Tutto lo staff (admin, maestra,
+assistente) vede l'informazione in Presenze e Pasti.
+
+## Obiettivo
+Permettere all'admin di dichiarare i giorni in cui l'asilo è chiuso
+(vacanze, ponti, chiusure straordinarie), e impedire che in quei giorni
+— così come ogni sabato e domenica — vengano registrate presenze o pasti
+(in futuro anche ore di lavoro del personale).
+
+## Scenario: creare un giorno di chiusura
+Dato che sono autenticato come admin
+Quando su `/admin/calendario` inserisco una data di inizio, una data di
+fine (es. dal 23 al 31 dicembre) ed eventualmente una nota (es. "Vacanze
+di Natale"), e confermo
+Allora il periodo compare nell'elenco dei giorni di chiusura, con
+l'intervallo e la nota mostrati
+
+## Scenario: la data di fine non può precedere quella di inizio
+Quando su `/admin/calendario` inserisco una data di fine antecedente
+alla data di inizio e confermo
+Allora vedo un messaggio d'errore e nessun giorno di chiusura viene
+creato
+
+## Scenario: un giorno di chiusura di un solo giorno
+Quando inserisco la stessa data sia come inizio sia come fine (es. un
+ponte di un solo giorno)
+Allora il periodo viene creato correttamente come chiusura di un solo
+giorno
+
+## Scenario: modificare un giorno di chiusura
+Dato che ho aperto la scheda di dettaglio di un giorno di chiusura
+esistente
+Quando trovo un form con i dati pre-caricati, modifico la data di fine
+e/o la nota, e confermo
+Allora i nuovi dati sono salvati e restano visibili riaprendo la scheda
+
+## Scenario: eliminare un giorno di chiusura
+Dato che sono sulla scheda di dettaglio di un giorno di chiusura
+Quando premo "Elimina" e confermo
+Allora il periodo scompare dall'elenco dei giorni di chiusura
+E da quel momento le date che ricadevano in quel periodo tornano
+normalmente scrivibili (salvo che siano sabato o domenica)
+
+## Scenario: sabato e domenica sono chiusura implicita
+Dato che una data è un sabato o una domenica
+Quando apro Presenze o Pasti per quella data, per una qualunque classe
+Allora vedo l'informazione che l'asilo è chiuso per quel giorno
+E questo vale sempre, anche se l'admin non ha creato nessun giorno di
+chiusura per quella data
+
+## Scenario: un giorno di chiusura è visibile e bloccante in Presenze
+Dato che una data ricade in un giorno di chiusura registrato dall'admin
+(o è sabato/domenica)
+Quando apro Presenze per quella data, per una classe
+Allora vedo un messaggio che segnala la chiusura (con la nota, se
+presente)
+E non vedo i pulsanti per segnare presente/assente/malattia/pre-asilo/
+post-asilo per nessun bambino, indipendentemente dal mio ruolo (admin
+incluso)
+
+## Scenario: un giorno di chiusura è visibile e bloccante in Pasti
+Dato che una data ricade in un giorno di chiusura registrato dall'admin
+(o è sabato/domenica)
+Quando apro Pasti per quella data, per una classe
+Allora vedo un messaggio che segnala la chiusura (con la nota, se
+presente)
+E non vedo i pulsanti sì/no per nessun bambino, indipendentemente dal
+mio ruolo (admin incluso)
+
+## Regole
+- Un giorno di chiusura ha una data di inizio, una data di fine (>=
+  data di inizio, vincolo anche a livello di database) e una nota
+  libera opzionale (`public.giorni_chiusura`).
+- Solo un profilo con ruolo `admin` può creare, modificare o eliminare
+  giorni di chiusura (RLS in
+  `supabase/migrations/0022_calendario_scolastico.sql`); tutto lo staff
+  (admin, maestra, assistente) può leggerli, perché Presenze e Pasti
+  devono mostrare l'informazione a chiunque.
+- Sabato e domenica sono chiusura implicita, calcolata dalla data
+  stessa (`extract(isodow from data)`, lato database; `lib/date.ts:isWeekend`
+  lato applicazione): non richiedono né permettono un record in
+  `giorni_chiusura`.
+- **A differenza della regola "sola data odierna" di
+  [13 - segna-presenza.md](13%20-%20segna-presenza.md) e
+  [14 - segna-pasto.md](14%20-%20segna-pasto.md) (che esenta l'admin),
+  il blocco di scrittura su un giorno chiuso vale per QUALUNQUE ruolo,
+  admin incluso**: non è un permesso di scrittura ma un vincolo di
+  coerenza dei dati (un asilo chiuso non ha presenze/pasti da
+  registrare, stesso principio già in vigore per "pasto di un bambino
+  assente/malato", vedi
+  [14 - segna-pasto.md](14%20-%20segna-pasto.md)). Imposto anche a
+  livello di database con un trigger su `presenze` e uno su `pasti`
+  (`supabase/migrations/0022_calendario_scolastico.sql`), non solo in
+  UI.
+- Il blocco riguarda l'inserimento e la modifica di presenze e pasti;
+  non elimina né nasconde eventuali dati già registrati in precedenza
+  su una data che diventa chiusa in un secondo momento (caso limite non
+  gestito automaticamente: se serve correggere dati storici, va fatto
+  eliminando prima il giorno di chiusura).
+- Non è verificata la sovrapposizione tra due giorni di chiusura
+  inseriti dall'admin: intervalli sovrapposti sono innocui (il giorno
+  risulta comunque chiuso), quindi non è un vincolo necessario per il
+  comportamento descritto sopra.
+- In futuro, lo stesso vincolo si applicherà anche alla registrazione
+  delle ore di lavoro del personale (fuori dallo scope di questa fase,
+  che non ha ancora quella funzionalità).

--- a/supabase/migrations/0022_calendario_scolastico.sql
+++ b/supabase/migrations/0022_calendario_scolastico.sql
@@ -1,0 +1,106 @@
+-- Girasole — Calendario scolastico: giorni di chiusura (specs/53 -
+-- calendario-scolastico.md). L'admin gestisce intervalli di chiusura
+-- (es. vacanze, ponti) con una nota opzionale; sabato e domenica sono
+-- chiusura implicita, senza bisogno di un record. In un giorno chiuso
+-- (weekend o intervallo registrato) non è possibile inserire né
+-- modificare presenze o pasti, per NESSUN ruolo (admin incluso — è un
+-- vincolo di coerenza dei dati, non un permesso di scrittura, stesso
+-- principio già in vigore per "pasto di un bambino assente/malato", vedi
+-- 0012_pasto_senza_parziale.sql / 0017_pasto_blocca_anche_malattia.sql).
+--
+-- Incolla questo file nel SQL Editor di Supabase (dopo 0021) ed
+-- eseguilo una volta sola.
+
+create table public.giorni_chiusura (
+  id uuid primary key default gen_random_uuid(),
+  data_inizio date not null,
+  data_fine date not null,
+  nota text,
+  creato_da uuid references public.profili(id),
+  created_at timestamptz not null default now(),
+  constraint giorni_chiusura_intervallo_valido check (data_fine >= data_inizio)
+);
+
+create index giorni_chiusura_intervallo_idx on public.giorni_chiusura (data_inizio, data_fine);
+
+alter table public.giorni_chiusura enable row level security;
+
+-- select: tutto lo staff (admin, maestra, assistente) deve poter vedere
+-- i giorni di chiusura in Presenze/Pasti, non solo l'admin che li gestisce.
+create policy "giorni_chiusura_select_staff" on public.giorni_chiusura
+  for select using (public.ruolo_corrente() in ('admin', 'maestra', 'assistente'));
+
+-- insert/update/delete: solo admin (specs/53).
+create policy "giorni_chiusura_insert_admin" on public.giorni_chiusura
+  for insert with check (public.ruolo_corrente() = 'admin');
+
+create policy "giorni_chiusura_update_admin" on public.giorni_chiusura
+  for update using (public.ruolo_corrente() = 'admin');
+
+create policy "giorni_chiusura_delete_admin" on public.giorni_chiusura
+  for delete using (public.ruolo_corrente() = 'admin');
+
+grant select, insert, update, delete on public.giorni_chiusura to authenticated;
+
+-- Grant preventivo per service_role: nessuna route lo usa ancora per
+-- leggere questa tabella, ma è lo stesso bug già capitato due volte per
+-- altre tabelle nuove (vedi 0018_grant_service_role_report.sql,
+-- 0019_pasti_comunicati_rojac.sql) — lo evitiamo da subito.
+grant select on public.giorni_chiusura to service_role;
+
+-- =========================================================
+-- "Giorno chiuso" = weekend O dentro un intervallo registrato. Funzione
+-- condivisa dai due trigger sotto e riusabile da eventuali query future.
+-- extract(isodow from data): 6 = sabato, 7 = domenica.
+-- =========================================================
+create or replace function public.giorno_chiuso(controllo date)
+returns boolean
+language sql stable
+as $$
+  select
+    extract(isodow from controllo) in (6, 7)
+    or exists (
+      select 1 from public.giorni_chiusura
+      where data_inizio <= controllo and data_fine >= controllo
+    );
+$$;
+
+-- =========================================================
+-- Blocco su presenze e pasti: vale per QUALUNQUE ruolo, admin incluso
+-- (a differenza del blocco "solo data odierna" di
+-- 0009_scrittura_solo_oggi_maestra.sql, che esenta l'admin) — vedi
+-- "Regole" in specs/53.
+-- =========================================================
+create or replace function public.impedisci_presenza_giorno_chiuso()
+returns trigger
+language plpgsql
+as $$
+begin
+  if public.giorno_chiuso(new.data) then
+    raise exception 'Impossibile segnare la presenza: % è un giorno di chiusura scolastica.', new.data;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists presenze_blocca_se_chiuso on public.presenze;
+create trigger presenze_blocca_se_chiuso
+  before insert or update on public.presenze
+  for each row execute procedure public.impedisci_presenza_giorno_chiuso();
+
+create or replace function public.impedisci_pasto_giorno_chiuso()
+returns trigger
+language plpgsql
+as $$
+begin
+  if public.giorno_chiuso(new.data) then
+    raise exception 'Impossibile segnare il pasto: % è un giorno di chiusura scolastica.', new.data;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists pasti_blocca_se_chiuso on public.pasti;
+create trigger pasti_blocca_se_chiuso
+  before insert or update on public.pasti
+  for each row execute procedure public.impedisci_pasto_giorno_chiuso();


### PR DESCRIPTION
## Summary
- Nuovo requisito `specs/53 - calendario-scolastico.md`: l'admin gestisce da `/admin/calendario` i giorni di chiusura scolastica (intervallo da/a + nota opzionale); sabato e domenica sono chiusura implicita, senza bisogno di un record.
- In un giorno chiuso non è possibile registrare presenze o pasti **per nessun ruolo, admin incluso** — vincolo di coerenza dei dati, non un permesso di scrittura (a differenza della regola "sola data odierna" già esistente, che esenta l'admin). Imposto sia in RLS/trigger (`supabase/migrations/0022_calendario_scolastico.sql`) sia in UI (Presenze/Pasti mostrano un banner con la nota al posto dei pulsanti).
- `specs/13`/`specs/14` aggiornate con un rimando incrociato a `specs/53` (stesso pattern già usato per `specs/06 - controllo-consistenza.md`, nessuna duplicazione di scenario/test).

## Test plan
- [x] `npx tsc --noEmit`, `npx next lint`, `npx vitest run` (131 test), `npx jscpd` — tutti puliti (verificato in locale e dal pre-push hook).
- [x] Nuovi unit test: `lib/date.test.ts` (`isWeekend`), `lib/calendarioScolastico.test.ts` (funzioni pure).
- [x] Nuovo `e2e/53-calendario-scolastico.spec.ts`: un test per ogni `## Scenario:` di `specs/53`, più i controlli axe-core.
- [ ] **Da fare prima/dopo il merge**: applica `supabase/migrations/0022_calendario_scolastico.sql` nel SQL Editor di Supabase (test e produzione) — senza, la tabella `giorni_chiusura` non esiste e `/admin/calendario` fallisce nel caricare l'elenco. Poi esegui `npx playwright test e2e/53-calendario-scolastico.spec.ts` (e le suite 13/14) dal tuo ambiente locale con le credenziali `E2E_*` — non eseguibile da questa sandbox (nessun dev server/credenziali Supabase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhMsAty4EqA8QwnDtb8H68

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhMsAty4EqA8QwnDtb8H68)_