### PR TITLE
Report notturno: corpo email in forma tabellare (v0.12.1)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1034,6 +1034,49 @@ Due bug segnalati dopo l'uso reale di `/admin/maestre`.
       — senza, la tabella `giorni_chiusura` non esiste e la pagina fallisce
       nel caricare l'elenco.
 
+## Corpo dell'email del report notturno in forma tabellare (v0.12.1)
+- [x] Richiesta dell'utente: il report notturno via email
+      (specs/52 - report-email-automatico.md) arrivava con i 3 PDF già
+      tabellari, ma il corpo dell'email stessa (visibile senza aprire
+      allegati) era ancora un elenco puntato (`<ul><li>`), residuo della
+      versione precedente all'introduzione dei PDF. Richiesto che anche
+      il corpo mostri la stessa tabella vista nella sezione Report a
+      schermo.
+- [x] `specs/52 - report-email-automatico.md` aggiornata: nuova frase
+      nello scenario "invio notturno dei tre report" e nella nota di
+      implementazione che richiede esplicitamente che anche il corpo
+      dell'email (non solo gli allegati PDF) sia una tabella per classe
+      con le colonne del report a schermo.
+- [x] `lib/reportPresenze.ts`: nuova funzione pura
+      `formattaTabellaReportHtml(titolo, sezioni)` (una `<table>` per
+      classe attiva, colonne Bambino/Presenze/Pre-asilo/Post-asilo/
+      Pasti, avviso ⚠️ accanto al nome quando ci sono inconsistenze —
+      stessa dicitura di `components/AvvisoInconsistenza.tsx`), unit
+      test in `lib/reportPresenze.test.ts`. `generaSchedaGiornalieraHtml`
+      (che eseguiva query proprie e produceva l'elenco puntato) sostituita
+      da `generaTabellaGiornalieraHtml`, che riusa
+      `aggregaReportPeriodoTutteLeClassi` (già usata per gli allegati PDF
+      settimanale/mensile) con `inizio = fine = data`, evitando di
+      duplicare la logica di aggregazione (CLAUDE.md, jscpd) — effetto
+      collaterale positivo: il corpo mail ora filtra bambini/classi
+      attivi come lo schermo (prima interrogava anche i bambini non
+      attivi).
+- [x] `app/api/cron/report-presenze/route.ts` aggiornata al nuovo nome di
+      funzione.
+- [x] Nessuna modifica alla generazione dei 3 PDF allegati
+      (`lib/pdfReport.ts`), già tabellari e allineati al report a schermo
+      da una sessione precedente.
+- [x] Verificato: `npx tsc --noEmit`, `npx next lint`, `npx vitest run`
+      (136 test) e `npx jscpd` (3 clone preesistenti, sotto soglia,
+      nessuno nuovo) puliti. Suite e2e Playwright non eseguibile da
+      questo ambiente sandbox (nessun dev server né credenziali
+      Supabase): da verificare con
+      `npx playwright test e2e/52-report-email-automatico.spec.ts` dal
+      tuo ambiente locale — quel file non fa assert sul contenuto HTML
+      del corpo email (nessuna infrastruttura di lettura casella email
+      nella suite), solo sull'idempotenza della route, quindi non è
+      impattato dal cambio di formato.
+
 ## Backlog — Fase 2/3
 - [ ] Rette mensili e stato pagamento
 - [ ] Portale genitori (UI dedicata)

--- a/app/api/cron/report-presenze/route.ts
+++ b/app/api/cron/report-presenze/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { inviaEmail, type AllegatoEmail } from '@/lib/email';
 import {
-  generaSchedaGiornalieraHtml,
+  generaTabellaGiornalieraHtml,
   aggregaReportPeriodoTutteLeClassi,
   recuperaComunicazioniPastiPeriodo,
   type SezioneConRighe,
@@ -193,7 +193,7 @@ export async function GET(request: Request) {
   if (daPreparare.length) {
     const allegati = await Promise.all(daPreparare.map((d) => d.genera()));
     const htmlGiornaliero = daPreparare.some((d) => d.tipo === 'giornaliero')
-      ? await generaSchedaGiornalieraHtml(dataReport)
+      ? await generaTabellaGiornalieraHtml(dataReport)
       : `<p>In allegato: ${daPreparare.map((d) => d.tipo).join(', ')}.</p>`;
 
     await inviaEmail({

--- a/lib/reportPresenze.test.ts
+++ b/lib/reportPresenze.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { righeOSollevaErrore } from './reportPresenze';
+import { righeOSollevaErrore, formattaTabellaReportHtml, type SezioneConRighe } from './reportPresenze';
+import type { RigaReportBambino } from './report';
 
 // righeOSollevaErrore è l'unica funzione pura di questo modulo (le altre
 // fanno query Supabase, coperte solo da e2e — vedi CLAUDE.md). Copre il
@@ -20,5 +21,69 @@ describe('righeOSollevaErrore', () => {
     expect(() =>
       righeOSollevaErrore({ data: null, error: { message: 'JWT invalid' } }, 'lettura sezioni')
     ).toThrow('lettura sezioni: JWT invalid');
+  });
+});
+
+function riga(sovrascrizioni: Partial<RigaReportBambino> = {}): RigaReportBambino {
+  return {
+    id: '1',
+    nome: 'Anna',
+    cognome: 'Bianchi',
+    presenze: 1,
+    preAsilo: 0,
+    postAsilo: 1,
+    pasti: 1,
+    inconsistenze: [],
+    ...sovrascrizioni,
+  };
+}
+
+// formattaTabellaReportHtml è la funzione pura che genera il corpo HTML
+// del report notturno (specs/52 - report-email-automatico.md): niente
+// I/O, chi chiama passa i dati già aggregati (stessa forma usata dalla
+// pagina Report a schermo e dai PDF email — vedi lib/pdfReport.test.ts).
+describe('formattaTabellaReportHtml', () => {
+  it('genera una tabella (non un elenco puntato) con le colonne del report a schermo', () => {
+    const sezioni: SezioneConRighe[] = [{ nome: 'Girasoli', righe: [riga()] }];
+    const html = formattaTabellaReportHtml('Presenze del 24 agosto 2026', sezioni);
+
+    expect(html).not.toContain('<ul>');
+    expect(html).not.toContain('<li>');
+    expect(html).toContain('<table');
+    expect(html).toContain('Girasoli');
+    expect(html).toContain('Anna Bianchi');
+    expect(html).toContain('Bambino');
+    expect(html).toContain('Presenze');
+    expect(html).toContain('Pre-asilo');
+    expect(html).toContain('Post-asilo');
+    expect(html).toContain('Pasti');
+  });
+
+  it('senza classi mostra "Nessuna classe attiva"', () => {
+    const html = formattaTabellaReportHtml('Presenze del 24 agosto 2026', []);
+    expect(html).toContain('Nessuna classe attiva.');
+  });
+
+  it('una classe senza bambini mostra "Nessun bambino in questa classe" (stessa dicitura dello schermo)', () => {
+    const sezioni: SezioneConRighe[] = [{ nome: 'Margherite', righe: [] }];
+    const html = formattaTabellaReportHtml('Presenze del 24 agosto 2026', sezioni);
+    expect(html).toContain('Margherite');
+    expect(html).toContain('Nessun bambino in questa classe.');
+    expect(html).not.toContain('<table');
+  });
+
+  it('un bambino con inconsistenze mostra l\'avviso ⚠️', () => {
+    const sezioni: SezioneConRighe[] = [
+      { nome: 'Girasoli', righe: [riga({ inconsistenze: ['Pasto segnato ma presenza assente.'] })] },
+    ];
+    const html = formattaTabellaReportHtml('Presenze del 24 agosto 2026', sezioni);
+    expect(html).toContain('⚠️');
+    expect(html).toContain('Pasto segnato ma presenza assente.');
+  });
+
+  it('un bambino senza inconsistenze non mostra alcun avviso', () => {
+    const sezioni: SezioneConRighe[] = [{ nome: 'Girasoli', righe: [riga()] }];
+    const html = formattaTabellaReportHtml('Presenze del 24 agosto 2026', sezioni);
+    expect(html).not.toContain('⚠️');
   });
 });

--- a/lib/reportPresenze.ts
+++ b/lib/reportPresenze.ts
@@ -1,14 +1,7 @@
 import { createAdminClient } from '@/lib/supabase/admin';
 import { formattaDataItaliana } from '@/lib/date';
 import { aggregaConteggiPresenzePasti, type RigaReportBambino } from '@/lib/report';
-import { inconsistenzeGiorno, type StatoPasto, type StatoPresenza } from '@/lib/consistenza';
 import type { ComunicazionePasto } from '@/lib/comunicazionePasti';
-
-const ETICHETTE_STATO: Record<string, string> = {
-  presente: 'Presente',
-  assente: 'Assente',
-  malattia: 'Malattia',
-};
 
 // Se la query Supabase è fallita (es. service_role key mancante/non
 // valida, permessi), solleva un errore invece di trattarla come "nessun
@@ -26,65 +19,59 @@ export function righeOSollevaErrore<T>(
   return risultato.data ?? [];
 }
 
-// Scheda HTML delle presenze/assenze/malattie di una data, raggruppata
-// per classe attiva — usata dal report notturno (specs/52 -
-// report-email-automatico.md). Usa la service_role key (bypassa la
-// RLS): il cron non ha una sessione utente e deve poter leggere tutte
-// le classi.
-export async function generaSchedaGiornalieraHtml(data: string): Promise<string> {
-  const supabase = createAdminClient();
+export type SezioneConRighe = { nome: string; righe: RigaReportBambino[] };
 
-  const [rSezioni, rBambini, rPresenze, rPasti] = await Promise.all([
-    supabase.from('sezioni').select('id, nome').eq('attiva', true).order('nome'),
-    supabase.from('bambini').select('id, nome, cognome, sezione_id').order('cognome'),
-    supabase.from('presenze').select('bambino_id, stato, note, pre_asilo, post_asilo').eq('data', data),
-    supabase.from('pasti').select('bambino_id, mangiato').eq('data', data),
-  ]);
-  const sezioni = righeOSollevaErrore(rSezioni, 'lettura sezioni');
-  const bambini = righeOSollevaErrore(rBambini, 'lettura bambini');
-  const presenze = righeOSollevaErrore(rPresenze, 'lettura presenze');
-  const pasti = righeOSollevaErrore(rPasti, 'lettura pasti');
+const STILE_TABELLA = 'border-collapse:collapse;width:100%';
+const STILE_CELLA = 'border:1px solid #ccc;padding:4px 8px;text-align:left';
+const STILE_CELLA_NUMERO = 'border:1px solid #ccc;padding:4px 8px;text-align:right';
 
-  const presenzaPerBambino = new Map(presenze.map((p) => [p.bambino_id, p]));
-  const pastoPerBambino = new Map(pasti.map((p) => [p.bambino_id, p.mangiato]));
+// Riga di una tabella HTML per un bambino, con lo stesso avviso ⚠️
+// mostrato accanto al nome nella tabella a schermo
+// (components/AvvisoInconsistenza.tsx) quando ci sono inconsistenze
+// (specs/06 - controllo-consistenza.md).
+function rigaHtml(r: RigaReportBambino): string {
+  const avviso = r.inconsistenze.length
+    ? ` <span title="${r.inconsistenze.join(' ')}">⚠️ Inconsistenza</span>`
+    : '';
+  return `<tr><td style="${STILE_CELLA}">${r.nome} ${r.cognome}${avviso}</td><td style="${STILE_CELLA_NUMERO}">${r.presenze}</td><td style="${STILE_CELLA_NUMERO}">${r.preAsilo}</td><td style="${STILE_CELLA_NUMERO}">${r.postAsilo}</td><td style="${STILE_CELLA_NUMERO}">${r.pasti}</td></tr>`;
+}
 
+// Corpo HTML del report notturno (specs/52 - report-email-automatico.md):
+// una tabella per classe attiva, stesse colonne e stesso raggruppamento
+// del report a schermo (app/dashboard/report/page.tsx) — non più un
+// elenco puntato. Funzione pura (nessun I/O): chi chiama ha già
+// aggregato i dati (aggregaReportPeriodoTutteLeClassi), stessa forma
+// usata per i PDF (lib/pdfReport.ts), per non duplicare la logica di
+// presentazione in più posti (CLAUDE.md, jscpd).
+export function formattaTabellaReportHtml(titolo: string, sezioni: SezioneConRighe[]): string {
   const sezioniHtml = sezioni
     .map((sezione) => {
-      const bambiniSezione = bambini.filter((b) => b.sezione_id === sezione.id);
-      if (!bambiniSezione.length) return '';
-
-      const righe = bambiniSezione
-        .map((b) => {
-          const presenza = presenzaPerBambino.get(b.id);
-          const stato = presenza ? ETICHETTE_STATO[presenza.stato] ?? presenza.stato : 'Non segnato';
-          const extra: string[] = [];
-          if (presenza?.pre_asilo) extra.push('pre-asilo');
-          if (presenza?.post_asilo) extra.push('post-asilo');
-          const pasto = pastoPerBambino.get(b.id);
-          if (pasto) extra.push(`pasto: ${pasto === 'si' ? 'sì' : 'no'}`);
-          const dettaglio = extra.length ? ` (${extra.join(', ')})` : '';
-          const nota = presenza?.note ? ` — ${presenza.note}` : '';
-          const problemi = inconsistenzeGiorno({
-            stato: presenza?.stato as StatoPresenza | undefined,
-            preAsilo: presenza?.pre_asilo,
-            postAsilo: presenza?.post_asilo,
-            mangiato: pasto as StatoPasto | undefined,
-          });
-          const avviso = problemi.length ? ` ⚠️ <em>${problemi.join(' ')}</em>` : '';
-          return `<li>${b.nome} ${b.cognome}: <strong>${stato}</strong>${dettaglio}${nota}${avviso}</li>`;
-        })
-        .join('');
-
-      return `<h2>${sezione.nome}</h2><ul>${righe}</ul>`;
+      const corpo = sezione.righe.length
+        ? `<table style="${STILE_TABELLA}"><thead><tr>` +
+          `<th style="${STILE_CELLA}">Bambino</th>` +
+          `<th style="${STILE_CELLA_NUMERO}">Presenze</th>` +
+          `<th style="${STILE_CELLA_NUMERO}">Pre-asilo</th>` +
+          `<th style="${STILE_CELLA_NUMERO}">Post-asilo</th>` +
+          `<th style="${STILE_CELLA_NUMERO}">Pasti</th>` +
+          `</tr></thead><tbody>${sezione.righe.map(rigaHtml).join('')}</tbody></table>`
+        : '<p>Nessun bambino in questa classe.</p>';
+      return `<h2>${sezione.nome}</h2>${corpo}`;
     })
     .join('');
 
-  return `<h1>Presenze del ${formattaDataItaliana(data)}</h1>${
-    sezioniHtml || '<p>Nessuna classe attiva.</p>'
-  }`;
+  return `<h1>${titolo}</h1>${sezioniHtml || '<p>Nessuna classe attiva.</p>'}`;
 }
 
-export type SezioneConRighe = { nome: string; righe: RigaReportBambino[] };
+// Corpo HTML del report notturno per un solo giorno — usata come corpo
+// dell'email dal job notturno (specs/52). Usa la service_role key
+// (bypassa la RLS): il cron non ha una sessione utente e deve poter
+// leggere tutte le classi. Riusa aggregaReportPeriodoTutteLeClassi (con
+// inizio = fine = data) per non duplicare la logica di aggregazione già
+// scritta per il settimanale/mensile e per i PDF (CLAUDE.md, jscpd).
+export async function generaTabellaGiornalieraHtml(data: string): Promise<string> {
+  const sezioni = await aggregaReportPeriodoTutteLeClassi(data, data);
+  return formattaTabellaReportHtml(`Presenze del ${formattaDataItaliana(data)}`, sezioni);
+}
 
 // Aggrega presenze (incluse pre-asilo/post-asilo) e pasti per ogni
 // classe attiva, nel periodo [inizio, fine] — usata dal report

--- a/lib/versione.ts
+++ b/lib/versione.ts
@@ -4,5 +4,5 @@
 // ora, minuti e secondi (fuso Europe/Rome, non UTC — coerente con
 // lib/date.ts), non solo la data: utile per distinguere più rilasci
 // fatti nello stesso giorno.
-export const VERSIONE_APP = '0.12.0';
-export const DATA_BUILD = '2026-08-28 19:40:04';
+export const VERSIONE_APP = '0.12.1';
+export const DATA_BUILD = '2026-08-29 19:32:43';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "girasole",
-  "version": "0.1.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "girasole",
-      "version": "0.1.0",
+      "version": "0.12.1",
       "dependencies": {
         "@supabase/ssr": "^0.5.1",
         "@supabase/supabase-js": "^2.45.0",
@@ -355,9 +355,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -373,9 +370,6 @@
       "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -393,9 +387,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -411,9 +402,6 @@
       "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -685,9 +673,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -705,9 +690,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -725,9 +707,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -745,9 +724,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -765,9 +741,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -785,9 +758,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1479,9 +1449,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1496,9 +1463,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1513,9 +1477,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1530,9 +1491,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1547,9 +1505,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1564,9 +1519,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1581,9 +1533,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1598,9 +1547,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1615,9 +1561,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1632,9 +1575,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4638,9 +4578,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4655,9 +4592,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4672,9 +4606,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4932,9 +4863,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4956,9 +4884,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4980,9 +4905,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5004,9 +4926,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5777,6 +5696,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "girasole",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/specs/52 - report-email-automatico.md
+++ b/specs/52 - report-email-automatico.md
@@ -36,6 +36,12 @@ per classe attiva, con presenze, presenze pre-asilo, presenze post-asilo
 e pasti "sì"
 E ciascun PDF riporta in intestazione il periodo a cui si riferisce e la
 data di generazione, in un formato adatto alla stampa (A4 verticale)
+E il corpo stesso dell'email (non solo gli allegati PDF) mostra il
+riepilogo del giorno appena concluso in forma tabellare — una tabella
+per classe attiva, con le stesse colonne del report giornaliero a
+schermo (Bambino, Presenze, Pre-asilo, Post-asilo, Pasti) — non più un
+elenco puntato: così il contenuto è leggibile anche senza aprire un
+allegato, sia su client email desktop che mobile
 
 ## Scenario: idempotenza per giorno
 Dato che il job è già stato eseguito con successo per il giorno X
@@ -116,8 +122,9 @@ un'informazione utile quanto la presenza)
   libreria PDF leggera lato server, oppure il rendering HTML→PDF di una
   pagina già esistente) resta un passaggio da concordare esplicitamente
   in fase di implementazione, non è stata decisa qui.
-- Il contenuto dei tre PDF riusa la stessa logica di aggregazione già
-  scritta per la UI di [51 - report.md](51%20-%20report.md)
-  (`lib/report.ts`), per evitare di duplicare il calcolo di presenze/
-  pasti/pre-asilo/post-asilo in due posti (vedi `CLAUDE.md`, sezione
-  Analisi statica — `jscpd`).
+- Il contenuto dei tre PDF, e quello della tabella nel corpo
+  dell'email, riusano la stessa logica di aggregazione già scritta per
+  la UI di [51 - report.md](51%20-%20report.md) (`lib/report.ts`), per
+  evitare di duplicare il calcolo di presenze/pasti/pre-asilo/
+  post-asilo in più posti (vedi `CLAUDE.md`, sezione Analisi statica —
+  `jscpd`).


### PR DESCRIPTION
## Summary
- I 3 PDF allegati del report notturno (giornaliero/settimanale/mensile) erano già tabellari e allineati al report a schermo. Il corpo dell'email stesso restava però un elenco puntato (`<ul><li>`), residuo della versione precedente all'introduzione dei PDF.
- `lib/reportPresenze.ts`: nuova funzione pura `formattaTabellaReportHtml` (una `<table>` per classe attiva, colonne Bambino/Presenze/Pre-asilo/Post-asilo/Pasti, avviso ⚠️ per le inconsistenze). `generaSchedaGiornalieraHtml` sostituita da `generaTabellaGiornalieraHtml`, che riusa `aggregaReportPeriodoTutteLeClassi` (già usata per i PDF) invece di query proprie, eliminando duplicazione.
- `specs/52 - report-email-automatico.md` aggiornata con il nuovo requisito.
- Versione app portata a `0.12.1`.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx next lint`
- [x] `npx vitest run` (136 test, inclusi i nuovi unit test per `formattaTabellaReportHtml`)
- [x] `npx jscpd` (nessun nuovo duplicato)
- [ ] `npx playwright test e2e/52-report-email-automatico.spec.ts` dal tuo ambiente locale (non eseguibile in questo ambiente sandbox — nessun dev server/credenziali Supabase). Il file non asserisce sul contenuto HTML del corpo email (nessuna infrastruttura per leggere la casella email), quindi non è impattato dal cambio di formato.

---
_Generated by [Claude Code](https://claude.ai/code/session_0165puuH5x8UEN9SYds2KVhF)_