### PR TITLE
Ore di lavoro: abilitazione per utente e quarta sezione in dashboard (v0.13.0)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1077,6 +1077,59 @@ Due bug segnalati dopo l'uso reale di `/admin/maestre`.
       nella suite), solo sull'idempotenza della route, quindi non è
       impattato dal cambio di formato.
 
+## Ore di lavoro: abilitazione per utente e quarta sezione in dashboard (v0.13.0)
+- [x] Richiesta dell'utente: primo passo verso la possibilità, per il
+      personale retribuito, di segnare le ore di lavoro effettuate o le
+      assenze. In questa fase si abilita solo l'accesso a una nuova
+      sezione "Ore di lavoro" (quarta, insieme a Presenze/Pasti/Report),
+      per utente, decisa dall'admin — **non** come le ore vengono
+      effettivamente registrate (fuori scope, fase successiva).
+- [x] Nuovo `specs/17 - ore-di-lavoro.md` (aggiunto all'indice in
+      `specs/00 - overview.md`); `specs/03 - utenti-e-ruoli.md` esteso
+      con il nuovo campo utente; `specs/12 - dashboard-maestre.md`
+      esteso con lo scenario della quarta card e la regola della griglia
+      bilanciata.
+- [x] `supabase/migrations/0023_ore_lavoro_abilitazione.sql`: nuova
+      colonna `profili.abilitato_ore_lavoro` (booleano, default falso).
+      Nessuna nuova policy RLS necessaria (colonna coperta dalle policy
+      di riga già esistenti su `profili`).
+- [x] `lib/auth.ts`: `Profilo` include ora `abilitato_ore_lavoro`
+      (letto da `requireProfilo`); nuova `assicuraAccessoOreLavoro`
+      (redirect a `/dashboard` se non abilitato — stesso pattern di
+      `assicuraAccessoPasti`), usata dalla nuova pagina
+      `app/dashboard/ore-lavoro/page.tsx` (placeholder: nessuna form,
+      solo il messaggio che la funzione arriva in una fase successiva).
+- [x] `lib/dashboardSezioni.ts` (nuovo, puro): `cardsDashboard` costruisce
+      l'elenco delle card Presenze/Pasti/Report/Ore di lavoro secondo
+      ruolo/sezioni assegnate/abilitazione, con la logica della griglia
+      bilanciata a due colonne (l'ultima card occupa l'intera larghezza
+      quando il numero visibile è dispari) — unit test in
+      `lib/dashboardSezioni.test.ts`. `app/dashboard/page.tsx`
+      semplificata: un'unica griglia invece del blocco Presenze/Pasti
+      più il pulsante Report separato di prima (Report ora ha lo stesso
+      stile "card grande" degli altri, non più una barra sottile).
+- [x] `/admin/maestre`: nuovo checkbox "Abilita al report ore di lavoro"
+      nel form di creazione e "Ore di lavoro" nella riga di modifica di
+      ogni utente (`app/admin/maestre/page.tsx`,
+      `app/admin/maestre/actions.ts:campiUtente/creaUtente/aggiornaUtente`).
+- [x] Verificato: `npx tsc --noEmit`, `npx next lint`, `npx vitest run`
+      (144 test) e `npx jscpd` (3 clone preesistenti, sotto soglia,
+      nessuno nuovo) puliti. Suite e2e Playwright non eseguibile da
+      questo ambiente sandbox (nessun dev server né credenziali
+      Supabase): nuovo `e2e/17-ore-di-lavoro.spec.ts` (un test per
+      ciascuno dei 5 scenari di specs/17, incluso axe-core sulla nuova
+      pagina) da verificare con
+      `npx playwright test e2e/17-ore-di-lavoro.spec.ts` (e riesegui
+      12, 03) dal tuo ambiente locale.
+- [ ] **Da fare da parte tua**: applica
+      `supabase/migrations/0023_ore_lavoro_abilitazione.sql` nel SQL
+      Editor di Supabase (test e produzione) prima di usare la nuova
+      abilitazione — senza, `/admin/maestre` e la dashboard falliscono
+      a leggere/scrivere la colonna `abilitato_ore_lavoro`.
+
 ## Backlog — Fase 2/3
 - [ ] Rette mensili e stato pagamento
 - [ ] Portale genitori (UI dedicata)
+- [ ] Ore di lavoro: come il personale segna effettivamente ore
+      lavorate/assenze (form, calcolo, riepiloghi, export) — questa
+      abilitazione (v0.13.0) è solo il primo passo

--- a/app/admin/maestre/actions.ts
+++ b/app/admin/maestre/actions.ts
@@ -8,7 +8,8 @@ import type { EsitoAzione } from '@/components/FormConEsito';
 
 const RUOLI_VALIDI = ['admin', 'maestra', 'assistente', 'genitore'] as const;
 
-// Campi condivisi da creazione e modifica di un utente (specs/03).
+// Campi condivisi da creazione e modifica di un utente (specs/03,
+// specs/17 - ore-di-lavoro.md per abilitatoOreLavoro).
 function campiUtente(formData: FormData) {
   return {
     nome: ((formData.get('nome') as string) || '').trim(),
@@ -17,6 +18,7 @@ function campiUtente(formData: FormData) {
     ruolo: formData.get('ruolo') as string,
     indirizzoResidenza: ((formData.get('indirizzo_residenza') as string) || '').trim(),
     note: ((formData.get('note') as string) || '').trim(),
+    abilitatoOreLavoro: formData.get('abilitato_ore_lavoro') === 'on',
   };
 }
 
@@ -32,7 +34,7 @@ export async function creaUtente(_stato: EsitoAzione, formData: FormData): Promi
   const email = ((formData.get('email') as string) || '').trim().toLowerCase();
   const password = (formData.get('password') as string) || '';
   const confermaPassword = (formData.get('conferma_password') as string) || '';
-  const { nome, cognome, telefono, ruolo, indirizzoResidenza, note } = campiUtente(formData);
+  const { nome, cognome, telefono, ruolo, indirizzoResidenza, note, abilitatoOreLavoro } = campiUtente(formData);
 
   if (
     !email ||
@@ -67,10 +69,10 @@ export async function creaUtente(_stato: EsitoAzione, formData: FormData): Promi
     return { ok: false, messaggio: "Non è stato possibile creare l'utente. Riprova.", dettaglio: error.message };
   }
 
-  if (indirizzoResidenza || note) {
+  if (indirizzoResidenza || note || abilitatoOreLavoro) {
     await supabase
       .from('profili')
-      .update({ indirizzo_residenza: indirizzoResidenza, note })
+      .update({ indirizzo_residenza: indirizzoResidenza, note, abilitato_ore_lavoro: abilitatoOreLavoro })
       .eq('id', data.user!.id);
   }
 
@@ -84,7 +86,7 @@ export async function aggiornaUtente(
 ): Promise<EsitoAzione> {
   const { supabase } = await requireAdmin();
   const profiloId = formData.get('profilo_id') as string;
-  const { nome, cognome, telefono, ruolo, indirizzoResidenza, note } = campiUtente(formData);
+  const { nome, cognome, telefono, ruolo, indirizzoResidenza, note, abilitatoOreLavoro } = campiUtente(formData);
 
   if (!profiloId || !RUOLI_VALIDI.includes(ruolo as (typeof RUOLI_VALIDI)[number])) {
     return { ok: false, messaggio: 'Dati utente non validi.' };
@@ -92,7 +94,15 @@ export async function aggiornaUtente(
 
   const { error } = await supabase
     .from('profili')
-    .update({ nome, cognome, telefono, ruolo, indirizzo_residenza: indirizzoResidenza, note })
+    .update({
+      nome,
+      cognome,
+      telefono,
+      ruolo,
+      indirizzo_residenza: indirizzoResidenza,
+      note,
+      abilitato_ore_lavoro: abilitatoOreLavoro,
+    })
     .eq('id', profiloId);
   if (error) {
     return { ok: false, messaggio: "Impossibile aggiornare l'utente.", dettaglio: error.message };

--- a/app/admin/maestre/page.tsx
+++ b/app/admin/maestre/page.tsx
@@ -27,7 +27,7 @@ export default async function MaestrePage() {
   const [{ data: profili }, { data: sezioni }, { data: assegnazioni }] = await Promise.all([
     supabase
       .from('profili')
-      .select('id, nome, cognome, email, telefono, ruolo, indirizzo_residenza, note')
+      .select('id, nome, cognome, email, telefono, ruolo, indirizzo_residenza, note, abilitato_ore_lavoro')
       .order('cognome'),
     supabase.from('sezioni').select('id, nome').order('nome'),
     supabase.from('maestre_sezioni').select('maestra_id, sezione_id'),
@@ -111,6 +111,10 @@ export default async function MaestrePage() {
                 placeholder="Note (opzionale)"
                 className="rounded-lg border border-stone-300 px-3 py-2 text-sm outline-none focus:border-stone-500 sm:col-span-2"
               />
+              <label className="flex items-center gap-2 text-sm text-stone-700 sm:col-span-2">
+                <input type="checkbox" name="abilitato_ore_lavoro" className="h-4 w-4" />
+                Abilita al report ore di lavoro
+              </label>
               <PulsanteInvio className="rounded-lg bg-emerald-700 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-800 sm:col-span-2">
                 Crea utente
               </PulsanteInvio>
@@ -165,6 +169,15 @@ export default async function MaestrePage() {
                       </option>
                     ))}
                   </select>
+                  <label className="flex items-center gap-1 text-xs text-stone-700">
+                    <input
+                      type="checkbox"
+                      name="abilitato_ore_lavoro"
+                      defaultChecked={p.abilitato_ore_lavoro}
+                      className="h-3.5 w-3.5"
+                    />
+                    Ore di lavoro
+                  </label>
                   <PulsanteInvio className="rounded-lg bg-emerald-700 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-800">
                     Aggiorna
                   </PulsanteInvio>

--- a/app/dashboard/ore-lavoro/page.tsx
+++ b/app/dashboard/ore-lavoro/page.tsx
@@ -1,0 +1,32 @@
+import { NavHeader } from '@/components/NavHeader';
+import { requireStaff, assicuraAccessoOreLavoro } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+// Punto d'ingresso della sezione "Ore di lavoro" (specs/17 -
+// ore-di-lavoro.md): in questa fase abilita solo l'accesso, senza alcuna
+// form — la registrazione vera e propria di ore/assenze è fuori scope,
+// verrà definita in una fase successiva.
+export default async function OreLavoroPage() {
+  const { user, profilo, ruolo } = await requireStaff({});
+  assicuraAccessoOreLavoro(profilo?.abilitato_ore_lavoro);
+
+  const nomeVisualizzato = profilo?.nome || user.email || '';
+
+  return (
+    <>
+      <NavHeader nome={nomeVisualizzato} ruolo={ruolo} />
+      <main className="mx-auto max-w-2xl px-4 py-10">
+        <a href="/dashboard" className="text-sm text-stone-600 hover:text-stone-900">
+          ← Torna alla dashboard
+        </a>
+        <h1 className="mt-2 text-lg font-medium">Ore di lavoro</h1>
+        <div className="mt-6 rounded-xl border border-dashed border-stone-300 p-6 text-sm text-stone-600">
+          La registrazione delle ore di lavoro effettuate (o delle assenze) sarà disponibile in
+          una fase successiva. Per ora questa sezione conferma solo che sei abilitata a usarla —
+          chiedi all&rsquo;admin se pensavi di esserlo e non la vedi.
+        </div>
+      </main>
+    </>
+  );
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -7,6 +7,7 @@ import { SelettoreDestinatarioAvviso } from '@/components/SelettoreDestinatarioA
 import { requireProfilo } from '@/lib/auth';
 import { oggi } from '@/lib/date';
 import { sezioniAttiveVisibili, bambiniAttiviVisibili } from '@/lib/sezioni';
+import { cardsDashboard } from '@/lib/dashboardSezioni';
 import { creaPromemoria } from './actions';
 
 export const dynamic = 'force-dynamic';
@@ -39,6 +40,7 @@ export default async function DashboardPage({
   const data = searchParams.data || oggi();
   const sezioni = await sezioniAttiveVisibili(supabase, user.id, ruolo);
   const haSezioni = ruolo === 'admin' || sezioni.length > 0;
+  const cards = cardsDashboard({ data, haSezioni, ruolo, abilitatoOreLavoro: profilo?.abilitato_ore_lavoro });
 
   const bambini = await bambiniAttiviVisibili(
     supabase,
@@ -79,38 +81,22 @@ export default async function DashboardPage({
             </p>
           )}
 
-          {haSezioni && (
-            <div className={ruolo === 'assistente' ? 'grid grid-cols-1 gap-4' : 'grid grid-cols-2 gap-4'}>
+          <div className="grid grid-cols-2 gap-4">
+            {cards.map((c) => (
               <Link
-                href={`/dashboard/presenze?data=${data}`}
-                className="rounded-2xl bg-emerald-700 px-4 py-8 text-center text-lg font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-emerald-800 hover:shadow-md"
+                key={c.href}
+                href={c.href}
+                className={`rounded-2xl ${c.classi} px-4 py-8 text-center text-lg font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:shadow-md ${
+                  c.spanIntero ? 'col-span-2' : ''
+                }`}
               >
                 <span className="block text-3xl" aria-hidden="true">
-                  ☑️
+                  {c.icona}
                 </span>
-                Presenze
+                {c.etichetta}
               </Link>
-              {ruolo !== 'assistente' && (
-                <Link
-                  href={`/dashboard/pasti?data=${data}`}
-                  className="rounded-2xl bg-amber-700 px-4 py-8 text-center text-lg font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-amber-800 hover:shadow-md"
-                >
-                  <span className="block text-3xl" aria-hidden="true">
-                    🍝
-                  </span>
-                  Pasti
-                </Link>
-              )}
-            </div>
-          )}
-
-          <Link
-            href="/dashboard/report"
-            className="flex items-center justify-center gap-2 rounded-xl bg-sky-700 px-4 py-3 text-center text-sm font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-sky-800 hover:shadow-md"
-          >
-            <span aria-hidden="true">📊</span>
-            Report
-          </Link>
+            ))}
+          </div>
         </section>
 
         <section>

--- a/e2e/17-ore-di-lavoro.spec.ts
+++ b/e2e/17-ore-di-lavoro.spec.ts
@@ -1,0 +1,123 @@
+// Requisito: specs/17 - ore-di-lavoro.md
+//
+// ATTENZIONE: il test di abilitazione modifica davvero il flag
+// abilitato_ore_lavoro sul profilo admin di test e lo ripristina a fine
+// test (try/finally, stesso pattern di 53-calendario-scolastico.spec.ts)
+// — un solo test lo fa, per evitare che due esecuzioni parallele
+// sull'unico account admin si contendano lo stesso flag (fullyParallel:
+// true, stessa cautela già presa in 16-comunicazione-pasti-rojac.spec.ts).
+import { test, expect } from '@playwright/test';
+import { hasCredenziali, nessunaViolazioneA11yGrave, statoAutenticazione } from './helpers';
+
+test.describe('17 — Ore di lavoro', () => {
+  test.describe('come admin', () => {
+    test.use({ storageState: statoAutenticazione('admin') });
+
+    test.beforeEach(async ({ page }) => {
+      test.skip(!hasCredenziali('admin'), 'richiede E2E_ADMIN_EMAIL/PASSWORD');
+    });
+
+    test('senza abilitazione: nessuna card in dashboard e accesso diretto reindirizza alla dashboard', async ({
+      page,
+    }) => {
+      await page.goto('/dashboard');
+      await expect(page.getByRole('link', { name: 'Ore di lavoro' })).toHaveCount(0);
+
+      await page.goto('/dashboard/ore-lavoro');
+      await page.waitForURL('/dashboard', { timeout: 20_000 });
+    });
+
+    test('abilitare/disabilitare un utente esistente mostra/nasconde la card e la sezione, che non ha alcuna form', async ({
+      page,
+    }) => {
+      await page.goto('/admin/maestre');
+      const rigaPropria = page.locator('li', { hasText: process.env.E2E_ADMIN_EMAIL! });
+      const checkbox = rigaPropria.getByLabel('Ore di lavoro');
+
+      try {
+        // Abilitazione: la spunta resta visibile riaprendo la pagina, la
+        // card compare in dashboard e apre la sezione dedicata, senza
+        // alcuna form (specs/17: solo l'abilitazione, non la funzione).
+        await checkbox.check();
+        await rigaPropria.getByRole('button', { name: 'Aggiorna' }).click();
+        await page.waitForTimeout(1000);
+        await page.reload();
+        await expect(page.locator('li', { hasText: process.env.E2E_ADMIN_EMAIL! }).getByLabel('Ore di lavoro')).toBeChecked();
+
+        await page.goto('/dashboard');
+        const link = page.getByRole('link', { name: 'Ore di lavoro' });
+        await expect(link).toBeVisible();
+        await expect(link).toContainText('🕒');
+
+        await link.click();
+        await page.waitForURL('/dashboard/ore-lavoro');
+        await expect(page.getByRole('heading', { name: 'Ore di lavoro' })).toBeVisible();
+        await expect(page.getByText(/fase successiva/)).toBeVisible();
+        await expect(page.locator('form')).toHaveCount(0);
+        await expect(page.locator('input')).toHaveCount(0);
+
+        await nessunaViolazioneA11yGrave(page);
+
+        // Disabilitazione: la card sparisce e l'accesso diretto reindirizza.
+        await page.goto('/admin/maestre');
+        const rigaDaDisabilitare = page.locator('li', { hasText: process.env.E2E_ADMIN_EMAIL! });
+        await rigaDaDisabilitare.getByLabel('Ore di lavoro').uncheck();
+        await rigaDaDisabilitare.getByRole('button', { name: 'Aggiorna' }).click();
+        await page.waitForTimeout(1000);
+        await page.reload();
+        await expect(
+          page.locator('li', { hasText: process.env.E2E_ADMIN_EMAIL! }).getByLabel('Ore di lavoro')
+        ).not.toBeChecked();
+
+        await page.goto('/dashboard');
+        await expect(page.getByRole('link', { name: 'Ore di lavoro' })).toHaveCount(0);
+        await page.goto('/dashboard/ore-lavoro');
+        await page.waitForURL('/dashboard', { timeout: 20_000 });
+      } finally {
+        await page.goto('/admin/maestre');
+        const rigaDaRipristinare = page.locator('li', { hasText: process.env.E2E_ADMIN_EMAIL! });
+        const checkboxDaRipristinare = rigaDaRipristinare.getByLabel('Ore di lavoro');
+        if (await checkboxDaRipristinare.isChecked()) {
+          await checkboxDaRipristinare.uncheck();
+          await rigaDaRipristinare.getByRole('button', { name: 'Aggiorna' }).click();
+          await page.waitForTimeout(1000);
+        }
+      }
+    });
+
+    test('creazione di un utente con abilitazione al report ore già attiva', async ({ page }) => {
+      const email = `e2e-ore-lavoro-${Date.now()}@example.com`;
+
+      await page.goto('/admin/maestre');
+      const formCreazione = page.locator('form', { has: page.getByRole('button', { name: 'Crea utente' }) });
+
+      await page.getByPlaceholder('Nome').first().fill('Prova');
+      await page.getByPlaceholder('Cognome').first().fill('OreLavoro');
+      await page.getByPlaceholder('Email').fill(email);
+      await page.getByPlaceholder('Telefono').first().fill('3331234567');
+      await page.getByLabel('Password', { exact: true }).fill('PasswordE2E!1');
+      await page.getByLabel('Conferma password').fill('PasswordE2E!1');
+      await formCreazione.getByLabel('Ore di lavoro').check();
+      await page.getByRole('button', { name: 'Crea utente' }).click();
+
+      const riga = page.getByText(email, { exact: false }).locator('..');
+      await expect(riga).toBeVisible({ timeout: 20_000 });
+      await expect(riga.getByLabel('Ore di lavoro')).toBeChecked();
+
+      await riga.getByRole('button', { name: 'Elimina utente' }).click();
+      await page.waitForTimeout(1000);
+      await expect(page.getByText(email, { exact: false })).toHaveCount(0);
+    });
+  });
+
+  test.describe('come maestra', () => {
+    test.use({ storageState: statoAutenticazione('maestra') });
+
+    test('senza abilitazione non vede la card "Ore di lavoro"', async ({ page }) => {
+      test.skip(!hasCredenziali('maestra'), 'richiede E2E_MAESTRA_EMAIL/PASSWORD');
+
+      await page.goto('/dashboard');
+      await expect(page.getByRole('link', { name: 'Ore di lavoro' })).toHaveCount(0);
+    });
+  });
+});

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -6,6 +6,7 @@ export type Profilo = {
   nome: string;
   cognome: string;
   ruolo: string;
+  abilitato_ore_lavoro: boolean;
 };
 
 // Richiede una sessione autenticata, senza requisiti di ruolo — usato
@@ -28,7 +29,7 @@ export async function requireProfilo() {
 
   const { data: profilo, error } = await supabase
     .from('profili')
-    .select('nome, cognome, ruolo')
+    .select('nome, cognome, ruolo, abilitato_ore_lavoro')
     .eq('id', user.id)
     .single();
 
@@ -72,6 +73,15 @@ export async function requireStaff(searchParams: { data?: string }) {
 // requireStaff(), su ogni pagina/azione di Pasti.
 export function assicuraAccessoPasti(ruolo: string | null | undefined): void {
   if (ruolo === 'assistente') redirect('/dashboard');
+}
+
+// L'accesso alla sezione "Ore di lavoro" (specs/17 -
+// ore-di-lavoro.md) dipende da un'abilitazione per singolo utente
+// decisa dall'admin (profili.abilitato_ore_lavoro), non dal ruolo —
+// nessun bypass nemmeno per l'admin: da chiamare, dopo requireStaff(),
+// sulla pagina di quella sezione.
+export function assicuraAccessoOreLavoro(abilitato: boolean | null | undefined): void {
+  if (!abilitato) redirect('/dashboard');
 }
 
 // La maestra e l'assistente possono scrivere (inserire/modificare)

--- a/lib/dashboardSezioni.test.ts
+++ b/lib/dashboardSezioni.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { cardsDashboard } from './dashboardSezioni';
+
+// cardsDashboard è pura (nessun I/O): copre la disposizione bilanciata
+// a due colonne richiesta da specs/12 e specs/17 — l'ultima card occupa
+// l'intera larghezza solo quando il numero di card visibili è dispari.
+describe('cardsDashboard', () => {
+  it('maestra con sezioni, senza abilitazione ore: Presenze, Pasti, Report — Report a larghezza intera (3, dispari)', () => {
+    const cards = cardsDashboard({ data: '2026-08-29', haSezioni: true, ruolo: 'maestra', abilitatoOreLavoro: false });
+
+    expect(cards.map((c) => c.etichetta)).toEqual(['Presenze', 'Pasti', 'Report']);
+    expect(cards[0].spanIntero).toBe(false);
+    expect(cards[1].spanIntero).toBe(false);
+    expect(cards[2].spanIntero).toBe(true);
+  });
+
+  it('maestra con sezioni e abilitazione ore: 4 card (pari), nessuna a larghezza intera', () => {
+    const cards = cardsDashboard({ data: '2026-08-29', haSezioni: true, ruolo: 'maestra', abilitatoOreLavoro: true });
+
+    expect(cards.map((c) => c.etichetta)).toEqual(['Presenze', 'Pasti', 'Report', 'Ore di lavoro']);
+    expect(cards.every((c) => !c.spanIntero)).toBe(true);
+  });
+
+  it('assistente con sezioni, senza Pasti: Presenze e Report (2, pari), nessuna a larghezza intera', () => {
+    const cards = cardsDashboard({ data: '2026-08-29', haSezioni: true, ruolo: 'assistente', abilitatoOreLavoro: false });
+
+    expect(cards.map((c) => c.etichetta)).toEqual(['Presenze', 'Report']);
+    expect(cards.every((c) => !c.spanIntero)).toBe(true);
+  });
+
+  it('assistente con sezioni e abilitazione ore: 3 card (dispari), Ore di lavoro a larghezza intera', () => {
+    const cards = cardsDashboard({ data: '2026-08-29', haSezioni: true, ruolo: 'assistente', abilitatoOreLavoro: true });
+
+    expect(cards.map((c) => c.etichetta)).toEqual(['Presenze', 'Report', 'Ore di lavoro']);
+    expect(cards[2].spanIntero).toBe(true);
+  });
+
+  it('senza sezioni assegnate: solo Report, a larghezza intera', () => {
+    const cards = cardsDashboard({ data: '2026-08-29', haSezioni: false, ruolo: 'maestra', abilitatoOreLavoro: false });
+
+    expect(cards.map((c) => c.etichetta)).toEqual(['Report']);
+    expect(cards[0].spanIntero).toBe(true);
+  });
+
+  it('senza sezioni ma con abilitazione ore: Report e Ore di lavoro (2, pari)', () => {
+    const cards = cardsDashboard({ data: '2026-08-29', haSezioni: false, ruolo: 'admin', abilitatoOreLavoro: true });
+
+    expect(cards.map((c) => c.etichetta)).toEqual(['Report', 'Ore di lavoro']);
+    expect(cards.every((c) => !c.spanIntero)).toBe(true);
+  });
+
+  it('gli href di Presenze e Pasti includono la data passata', () => {
+    const cards = cardsDashboard({ data: '2026-08-29', haSezioni: true, ruolo: 'maestra', abilitatoOreLavoro: false });
+
+    expect(cards[0].href).toBe('/dashboard/presenze?data=2026-08-29');
+    expect(cards[1].href).toBe('/dashboard/pasti?data=2026-08-29');
+  });
+
+  it('la card Ore di lavoro punta a /dashboard/ore-lavoro con l\'icona 🕒', () => {
+    const cards = cardsDashboard({ data: '2026-08-29', haSezioni: false, ruolo: 'admin', abilitatoOreLavoro: true });
+    const ore = cards.find((c) => c.etichetta === 'Ore di lavoro');
+
+    expect(ore?.href).toBe('/dashboard/ore-lavoro');
+    expect(ore?.icona).toBe('🕒');
+  });
+});

--- a/lib/dashboardSezioni.ts
+++ b/lib/dashboardSezioni.ts
@@ -1,0 +1,64 @@
+export type CardDashboard = {
+  href: string;
+  icona: string;
+  etichetta: string;
+  classi: string;
+  spanIntero: boolean;
+};
+
+// Costruisce l'elenco delle card/pulsanti della dashboard (specs/12 -
+// dashboard-maestre.md, specs/17 - ore-di-lavoro.md), in ordine, per una
+// griglia a due colonne bilanciata: quando il numero di card è dispari,
+// l'ultima ha spanIntero = true (occupa l'intera larghezza) per non
+// lasciare un buco vuoto in griglia. Funzione pura: chi chiama
+// (app/dashboard/page.tsx) ha già risolto ruolo/sezioni assegnate/
+// abilitazione, nessun I/O qui.
+export function cardsDashboard({
+  data,
+  haSezioni,
+  ruolo,
+  abilitatoOreLavoro,
+}: {
+  data: string;
+  haSezioni: boolean;
+  ruolo: string | null | undefined;
+  abilitatoOreLavoro: boolean | null | undefined;
+}): CardDashboard[] {
+  const cards: Omit<CardDashboard, 'spanIntero'>[] = [];
+
+  if (haSezioni) {
+    cards.push({
+      href: `/dashboard/presenze?data=${data}`,
+      icona: '☑️',
+      etichetta: 'Presenze',
+      classi: 'bg-emerald-700 hover:bg-emerald-800',
+    });
+    if (ruolo !== 'assistente') {
+      cards.push({
+        href: `/dashboard/pasti?data=${data}`,
+        icona: '🍝',
+        etichetta: 'Pasti',
+        classi: 'bg-amber-700 hover:bg-amber-800',
+      });
+    }
+  }
+
+  cards.push({
+    href: '/dashboard/report',
+    icona: '📊',
+    etichetta: 'Report',
+    classi: 'bg-sky-700 hover:bg-sky-800',
+  });
+
+  if (abilitatoOreLavoro) {
+    cards.push({
+      href: '/dashboard/ore-lavoro',
+      icona: '🕒',
+      etichetta: 'Ore di lavoro',
+      classi: 'bg-purple-700 hover:bg-purple-800',
+    });
+  }
+
+  const dispari = cards.length % 2 === 1;
+  return cards.map((c, i) => ({ ...c, spanIntero: dispari && i === cards.length - 1 }));
+}

--- a/lib/versione.ts
+++ b/lib/versione.ts
@@ -4,5 +4,5 @@
 // ora, minuti e secondi (fuso Europe/Rome, non UTC — coerente con
 // lib/date.ts), non solo la data: utile per distinguere più rilasci
 // fatti nello stesso giorno.
-export const VERSIONE_APP = '0.12.1';
-export const DATA_BUILD = '2026-08-29 19:32:43';
+export const VERSIONE_APP = '0.13.0';
+export const DATA_BUILD = '2026-08-29 21:01:00';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "girasole",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "girasole",
-      "version": "0.12.1",
+      "version": "0.13.0",
       "dependencies": {
         "@supabase/ssr": "^0.5.1",
         "@supabase/supabase-js": "^2.45.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "girasole",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/specs/00 - overview.md
+++ b/specs/00 - overview.md
@@ -55,6 +55,10 @@ della maestra, `5x` amministrazione.
   comunicare i pasti di una classe a Rojac (mensa esterna), blocco
   successivo delle modifiche per la maestra e log delle comunicazioni
   nei report
+- [17 - ore-di-lavoro.md](17%20-%20ore-di-lavoro.md) — abilitazione per
+  utente (decisa dall'admin) e punto d'ingresso in dashboard per la
+  futura registrazione delle ore di lavoro/assenze del personale
+  retribuito
 - [50 - amministrazione_base.md](50%20-%20amministrazione_base.md) — creazione
   sezioni/bambini e assegnazione maestre/assistenti alle sezioni (admin)
 - [51 - report.md](51%20-%20report.md) — report tabellari di

--- a/specs/03 - utenti-e-ruoli.md
+++ b/specs/03 - utenti-e-ruoli.md
@@ -26,6 +26,9 @@ utenti da `/admin/maestre`.
 - **nome**
 - **cognome**
 - **numero di telefono**
+- **abilitazione al report ore di lavoro** — checkbox, falsa di default;
+  decide se l'utente vede la sezione "Ore di lavoro" in dashboard (vedi
+  [17 - ore-di-lavoro.md](17%20-%20ore-di-lavoro.md))
 
 ## Ruoli
 Un utente ha uno e un solo ruolo, tra:

--- a/specs/12 - dashboard-maestre.md
+++ b/specs/12 - dashboard-maestre.md
@@ -16,6 +16,9 @@ Allora vedo un selettore di data con selezionata la data odierna
 E vedo due pulsanti/schede "Presenze" e "Pasti", ciascuno con un'icona
 (☑️ per Presenze, 🍝 per Pasti) oltre al testo
 E vedo anche il pulsante/scheda "Report" con la sua icona (📊)
+E se il mio profilo è abilitato al report ore, vedo anche il
+pulsante/scheda "Ore di lavoro" con la sua icona (🕒) — vedi
+[17 - ore-di-lavoro.md](17%20-%20ore-di-lavoro.md)
 
 ## Scenario: da Presenze si arriva alle classi e poi ai bambini
 Dato che sono sulla dashboard con una data selezionata
@@ -101,6 +104,12 @@ successiva, e nessun dato di altri bambini
 - Priorità a interfaccia rapida, pochi tap, testo leggibile: le maestre
   useranno l'app prevalentemente da smartphone, opzionalmente da tablet e
   desktop in sezione — vedi [01 - ux.md](01%20-%20ux.md).
+- Le card/pulsanti Presenze/Pasti/Report/Ore di lavoro condividono
+  un'unica griglia bilanciata a due colonne: quali card compaiono dipende
+  da ruolo, sezioni assegnate e abilitazione (vedi
+  [17 - ore-di-lavoro.md](17%20-%20ore-di-lavoro.md)), ma quando il
+  numero di card visibili è dispari l'ultima occupa l'intera larghezza,
+  per non lasciare un buco vuoto in griglia.
 - Il denominatore "Y" del riepilogo aggregato "Pasti: X/Y" conta **tutti**
   i bambini attivi di tutte le classi visibili, indipendentemente dal
   loro stato di presenza/assenza/malattia — a differenza del riepilogo

--- a/specs/17 - ore-di-lavoro.md
+++ b/specs/17 - ore-di-lavoro.md
@@ -1,0 +1,70 @@
+# 17 — Ore di lavoro
+
+## Attori
+Personale retribuito (maestra, assistente o admin) abilitato dall'admin.
+
+## Obiettivo
+Introdurre, in modo progressivo, la possibilità per il personale
+retribuito di registrare le ore di lavoro effettuate o le assenze. In
+questa prima fase si abilita solo l'accesso alla sezione, utente per
+utente, deciso dall'admin: **come** le ore vengono effettivamente
+segnate (form, calcolo del totale, riepiloghi, export) è fuori scope,
+sarà definito in una fase successiva.
+
+## Scenario: l'admin abilita un utente al report ore in fase di creazione
+Dato che sono autenticato come admin
+Quando su `/admin/maestre` creo un nuovo utente e spunto "Abilita al
+report ore di lavoro", poi confermo
+Allora l'utente viene creato con l'abilitazione già attiva
+
+## Scenario: l'admin abilita o disabilita il report ore modificando un utente esistente
+Dato che un utente esiste già
+Quando su `/admin/maestre` spunto o tolgo la spunta "Ore di lavoro" per
+quell'utente e premo "Aggiorna"
+Allora l'abilitazione è aggiornata e resta visibile (spuntata o meno)
+riaprendo la pagina
+
+## Scenario: un utente abilitato vede la sezione "Ore di lavoro" in dashboard
+Dato che sono autenticata come maestra, assistente o admin e il mio
+profilo è abilitato al report ore
+Quando apro la dashboard
+Allora vedo, insieme a Presenze/Pasti/Report, anche il pulsante/scheda
+"Ore di lavoro" con la sua icona (🕒)
+E tappandolo apro la sezione dedicata (`/dashboard/ore-lavoro`)
+
+## Scenario: un utente non abilitato non vede la sezione
+Dato che sono autenticata come maestra, assistente o admin e il mio
+profilo NON è abilitato al report ore
+Quando apro la dashboard
+Allora non vedo il pulsante/scheda "Ore di lavoro"
+E se provo ad aprire direttamente `/dashboard/ore-lavoro`, vengo
+reindirizzata alla dashboard invece di vedere il contenuto della sezione
+
+## Scenario: contenuto della sezione in questa fase
+Dato che sono abilitata al report ore e apro `/dashboard/ore-lavoro`
+Allora vedo un messaggio che spiega che la registrazione vera e propria
+(ore lavorate o assenze) sarà disponibile in una fase successiva
+E non vedo alcuna form per inserire dati: questa fase abilita solo
+l'accesso alla sezione, non la sua funzione
+
+## Regole
+- Nuovo campo `profili.abilitato_ore_lavoro` (booleano, default falso):
+  decide da solo la visibilità della sezione e l'accesso alla pagina,
+  indipendentemente dal ruolo — anche l'admin non la vede finché non
+  abilita anche il proprio profilo, esattamente come per qualunque altro
+  utente (nessun bypass per il ruolo `admin`).
+- Solo l'admin può modificare questo campo, dallo stesso form di
+  creazione/modifica utente di
+  [03 - utenti-e-ruoli.md](03%20-%20utenti-e-ruoli.md) — non è
+  disponibile altrove.
+- La dashboard (vedi [12 - dashboard-maestre.md](12%20-%20dashboard-maestre.md))
+  ridistribuisce le card/pulsanti (Presenze, Pasti, Report, Ore di
+  lavoro) in un'unica griglia bilanciata a due colonne: quali card
+  compaiono dipende da ruolo/sezioni assegnate/abilitazione (come già
+  oggi per Presenze/Pasti), ma la disposizione è sempre quella — quando
+  il numero di card visibili è dispari, l'ultima occupa l'intera
+  larghezza invece di lasciare un buco vuoto in griglia.
+- Fuori scope in questa fase: come le ore vengono effettivamente
+  registrate (form di inserimento, calcolo ore/assenze, riepiloghi,
+  export, eventuali approvazioni) — qui si abilita solo l'accesso al
+  punto d'ingresso della sezione.

--- a/supabase/migrations/0023_ore_lavoro_abilitazione.sql
+++ b/supabase/migrations/0023_ore_lavoro_abilitazione.sql
@@ -1,0 +1,16 @@
+-- Girasole — Requisito 17 (specs/17 - ore-di-lavoro.md): abilitazione
+-- per singolo utente alla sezione "Ore di lavoro" (personale retribuito
+-- che in una fase successiva potrà segnare ore lavorate/assenze). Solo
+-- l'abilitazione in questa fase: nessuna tabella per i dati veri e
+-- propri, che sono fuori scope (vedi specs/17).
+--
+-- Nessuna nuova policy RLS: la colonna è coperta dalle policy già
+-- esistenti su public.profili (profili_select_own_or_admin,
+-- profili_select_colleghe, profili_update_admin — 0001_init.sql,
+-- 0002_admin_e_maestre.sql, 0016_assistente_e_pre_post_asilo.sql), che
+-- sono a livello di riga, non di colonna.
+--
+-- Incolla questo file nel SQL Editor di Supabase (dopo
+-- 0022_calendario_scolastico.sql) ed eseguilo una volta sola.
+
+alter table public.profili add column if not exists abilitato_ore_lavoro boolean not null default false;


### PR DESCRIPTION
## Summary
- Primo passo verso la possibilità per il personale retribuito di segnare ore lavorate/assenze: nuova colonna `profili.abilitato_ore_lavoro` (`supabase/migrations/0023_ore_lavoro_abilitazione.sql`), gestita dall'admin in creazione/modifica utente su `/admin/maestre` (nuovo checkbox "Ore di lavoro"/"Abilita al report ore di lavoro").
- Nuova sezione "Ore di lavoro" (quarta, con icona 🕒), visibile in dashboard solo per gli utenti abilitati (`app/dashboard/ore-lavoro/page.tsx`, redirect a `/dashboard` se non abilitato, `lib/auth.ts:assicuraAccessoOreLavoro`). In questa fase è solo un placeholder — nessuna form: **come** il personale segnerà effettivamente le ore resta fuori scope, sarà definito in una fase successiva.
- Dashboard semplificata: `lib/dashboardSezioni.ts` (nuovo, puro, con unit test) costruisce Presenze/Pasti/Report/Ore di lavoro come un'unica griglia bilanciata a due colonne (l'ultima card occupa l'intera larghezza quando il numero visibile è dispari), al posto del blocco Presenze/Pasti più il pulsante Report separato di prima.
- Nuovo `specs/17 - ore-di-lavoro.md` (in indice su `specs/00`); `specs/03` e `specs/12` aggiornate di conseguenza.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx next lint`
- [x] `npx vitest run` (144 test, inclusi gli 8 nuovi unit test di `lib/dashboardSezioni.test.ts`)
- [x] `npx jscpd` (nessun nuovo duplicato, i 3 clone segnalati sono preesistenti)
- [ ] `npx playwright test e2e/17-ore-di-lavoro.spec.ts` dal tuo ambiente locale (non eseguibile in questo ambiente sandbox — nessun dev server/credenziali Supabase). Copre i 5 scenari di specs/17 (abilitazione in creazione, abilitazione/disabilitazione modificando un utente esistente con verifica di persistenza, comparsa/scomparsa della card in dashboard, redirect quando non abilitato, contenuto placeholder senza form), incluso axe-core sulla nuova pagina.
- [ ] Rieseguire anche `e2e/12-dashboard-maestre.spec.ts` e `e2e/03-utenti-e-ruoli.spec.ts` (pagine toccate) dal tuo ambiente locale.

## Da fare dopo il merge
- Applicare `supabase/migrations/0023_ore_lavoro_abilitazione.sql` nel SQL Editor di Supabase (progetto di test e produzione) — senza, `/admin/maestre` e la dashboard falliscono a leggere/scrivere la colonna `abilitato_ore_lavoro`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0165puuH5x8UEN9SYds2KVhF)_