### PR TITLE
Profili orari: definizione e assegnazione al personale (v0.14.0)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1127,9 +1127,61 @@ Due bug segnalati dopo l'uso reale di `/admin/maestre`.
       abilitazione — senza, `/admin/maestre` e la dashboard falliscono
       a leggere/scrivere la colonna `abilitato_ore_lavoro`.
 
+## Profili orari: definizione e assegnazione al personale (v0.14.0)
+- [x] Richiesta dell'utente: secondo passo verso le ore di lavoro del
+      personale. L'admin deve poter definire "orari tipo" settimanali
+      (es. "35 ore settimanali" = 7h lun-ven, "32 ore settimanali" = 4
+      giorni a 7h + 1 a 4h, "Assistente 15h" = 3h lun-ven) in un pannello
+      dedicato, e assegnarne uno a ciascuna persona. **Non** come questi
+      profili verranno poi usati per calcolare/validare le ore segnate
+      (fuori scope, fase successiva).
+- [x] Nuovo `specs/54 - profili-orari.md` (aggiunto all'indice in
+      `specs/00 - overview.md`); `specs/17 - ore-di-lavoro.md` e
+      `specs/03 - utenti-e-ruoli.md` estese con un riferimento incrociato
+      — l'assegnazione del profilo orario è **indipendente**
+      dall'abilitazione al report ore (due controlli separati, scelta
+      esplicita per restare semplici: CLAUDE.md, niente validazioni per
+      scenari che non servono ora).
+- [x] `supabase/migrations/0024_profili_orari.sql`: nuova tabella
+      `profili_orari` (nome + ore lun-ven, `numeric(4,2)`), RLS solo
+      admin (nessun altro ruolo la legge ancora); nuova colonna
+      `profili.profilo_orario_id` (`on delete set null`: eliminare un
+      profilo non blocca nulla, svuota solo l'assegnazione — stesso
+      pattern di `sezioni.anno_scolastico_id`).
+- [x] `lib/profiliOrari.ts` (nuovo, puro): `totaleOreSettimanali` somma
+      i 5 giorni (accetta anche stringhe numeriche, per come Postgres
+      può restituire una colonna `numeric` via PostgREST) — unit test in
+      `lib/profiliOrari.test.ts`.
+- [x] Nuova sezione admin `/admin/profili-orari` (elenco + creazione) e
+      `/admin/profili-orari/[id]` (modifica/eliminazione), stesso
+      pattern list+detail già usato per `/admin/calendario` (specs/53).
+      `components/CampiOreSettimana.tsx` (nuovo) condivide i 5 input
+      ore lun-ven tra creazione e modifica (CLAUDE.md, jscpd — evitato un
+      duplicato reale, non solo simile per forma). Link "Profili orari"
+      aggiunto a `NavHeader` per l'admin.
+- [x] `/admin/maestre`: nuovo menu "Profilo orario" (opzionale) nel form
+      di creazione e nella riga di modifica di ogni utente
+      (`app/admin/maestre/page.tsx`,
+      `app/admin/maestre/actions.ts:campiUtente/creaUtente/aggiornaUtente`),
+      indipendente dal checkbox "Ore di lavoro" già esistente.
+- [x] Verificato: `npx tsc --noEmit`, `npx next lint`, `npx vitest run`
+      (150 test) e `npx jscpd` (3 clone preesistenti, sotto soglia,
+      nessuno nuovo) puliti. Suite e2e Playwright non eseguibile da
+      questo ambiente sandbox (nessun dev server né credenziali
+      Supabase): nuovo `e2e/54-profili-orari.spec.ts` (7 test, uno per
+      scenario di specs/54, incluso axe-core) da verificare con
+      `npx playwright test e2e/54-profili-orari.spec.ts` dal tuo
+      ambiente locale.
+- [ ] **Da fare da parte tua**: applica
+      `supabase/migrations/0024_profili_orari.sql` nel SQL Editor di
+      Supabase (test e produzione) prima di usare `/admin/profili-orari`
+      — senza, la tabella `profili_orari` e la colonna
+      `profili.profilo_orario_id` non esistono.
+
 ## Backlog — Fase 2/3
 - [ ] Rette mensili e stato pagamento
 - [ ] Portale genitori (UI dedicata)
 - [ ] Ore di lavoro: come il personale segna effettivamente ore
-      lavorate/assenze (form, calcolo, riepiloghi, export) — questa
+      lavorate/assenze (form, calcolo, riepiloghi, export), e come i
+      profili orari (v0.14.0) entrano in quel calcolo — questa
       abilitazione (v0.13.0) è solo il primo passo

--- a/app/admin/maestre/actions.ts
+++ b/app/admin/maestre/actions.ts
@@ -9,8 +9,11 @@ import type { EsitoAzione } from '@/components/FormConEsito';
 const RUOLI_VALIDI = ['admin', 'maestra', 'assistente', 'genitore'] as const;
 
 // Campi condivisi da creazione e modifica di un utente (specs/03,
-// specs/17 - ore-di-lavoro.md per abilitatoOreLavoro).
+// specs/17 - ore-di-lavoro.md per abilitatoOreLavoro, specs/54 -
+// profili-orari.md per profiloOrarioId).
 function campiUtente(formData: FormData) {
+  const profiloOrarioId = (formData.get('profilo_orario_id') as string) || '';
+
   return {
     nome: ((formData.get('nome') as string) || '').trim(),
     cognome: ((formData.get('cognome') as string) || '').trim(),
@@ -19,6 +22,9 @@ function campiUtente(formData: FormData) {
     indirizzoResidenza: ((formData.get('indirizzo_residenza') as string) || '').trim(),
     note: ((formData.get('note') as string) || '').trim(),
     abilitatoOreLavoro: formData.get('abilitato_ore_lavoro') === 'on',
+    // Stringa vuota ("Nessun profilo orario") diventa null, non una FK
+    // verso una riga inesistente.
+    profiloOrarioId: profiloOrarioId || null,
   };
 }
 
@@ -34,7 +40,8 @@ export async function creaUtente(_stato: EsitoAzione, formData: FormData): Promi
   const email = ((formData.get('email') as string) || '').trim().toLowerCase();
   const password = (formData.get('password') as string) || '';
   const confermaPassword = (formData.get('conferma_password') as string) || '';
-  const { nome, cognome, telefono, ruolo, indirizzoResidenza, note, abilitatoOreLavoro } = campiUtente(formData);
+  const { nome, cognome, telefono, ruolo, indirizzoResidenza, note, abilitatoOreLavoro, profiloOrarioId } =
+    campiUtente(formData);
 
   if (
     !email ||
@@ -69,10 +76,15 @@ export async function creaUtente(_stato: EsitoAzione, formData: FormData): Promi
     return { ok: false, messaggio: "Non è stato possibile creare l'utente. Riprova.", dettaglio: error.message };
   }
 
-  if (indirizzoResidenza || note || abilitatoOreLavoro) {
+  if (indirizzoResidenza || note || abilitatoOreLavoro || profiloOrarioId) {
     await supabase
       .from('profili')
-      .update({ indirizzo_residenza: indirizzoResidenza, note, abilitato_ore_lavoro: abilitatoOreLavoro })
+      .update({
+        indirizzo_residenza: indirizzoResidenza,
+        note,
+        abilitato_ore_lavoro: abilitatoOreLavoro,
+        profilo_orario_id: profiloOrarioId,
+      })
       .eq('id', data.user!.id);
   }
 
@@ -86,7 +98,8 @@ export async function aggiornaUtente(
 ): Promise<EsitoAzione> {
   const { supabase } = await requireAdmin();
   const profiloId = formData.get('profilo_id') as string;
-  const { nome, cognome, telefono, ruolo, indirizzoResidenza, note, abilitatoOreLavoro } = campiUtente(formData);
+  const { nome, cognome, telefono, ruolo, indirizzoResidenza, note, abilitatoOreLavoro, profiloOrarioId } =
+    campiUtente(formData);
 
   if (!profiloId || !RUOLI_VALIDI.includes(ruolo as (typeof RUOLI_VALIDI)[number])) {
     return { ok: false, messaggio: 'Dati utente non validi.' };
@@ -102,6 +115,7 @@ export async function aggiornaUtente(
       indirizzo_residenza: indirizzoResidenza,
       note,
       abilitato_ore_lavoro: abilitatoOreLavoro,
+      profilo_orario_id: profiloOrarioId,
     })
     .eq('id', profiloId);
   if (error) {

--- a/app/admin/maestre/page.tsx
+++ b/app/admin/maestre/page.tsx
@@ -24,13 +24,16 @@ export const dynamic = 'force-dynamic';
 export default async function MaestrePage() {
   const { supabase, user, profilo: profiloCorrente } = await requireAdmin();
 
-  const [{ data: profili }, { data: sezioni }, { data: assegnazioni }] = await Promise.all([
+  const [{ data: profili }, { data: sezioni }, { data: assegnazioni }, { data: profiliOrari }] = await Promise.all([
     supabase
       .from('profili')
-      .select('id, nome, cognome, email, telefono, ruolo, indirizzo_residenza, note, abilitato_ore_lavoro')
+      .select(
+        'id, nome, cognome, email, telefono, ruolo, indirizzo_residenza, note, abilitato_ore_lavoro, profilo_orario_id'
+      )
       .order('cognome'),
     supabase.from('sezioni').select('id, nome').order('nome'),
     supabase.from('maestre_sezioni').select('maestra_id, sezione_id'),
+    supabase.from('profili_orari').select('id, nome').order('nome'),
   ]);
 
   const staffAssegnabile = profili?.filter((p) => p.ruolo === 'maestra' || p.ruolo === 'assistente') ?? [];
@@ -115,6 +118,22 @@ export default async function MaestrePage() {
                 <input type="checkbox" name="abilitato_ore_lavoro" className="h-4 w-4" />
                 Abilita al report ore di lavoro
               </label>
+              <label className="flex flex-col text-sm text-stone-700 sm:col-span-2">
+                Profilo orario (opzionale)
+                <select
+                  name="profilo_orario_id"
+                  defaultValue=""
+                  aria-label="Profilo orario"
+                  className="mt-1 rounded-lg border border-stone-300 px-3 py-2 text-sm outline-none focus:border-stone-500"
+                >
+                  <option value="">Nessun profilo orario</option>
+                  {profiliOrari?.map((po) => (
+                    <option key={po.id} value={po.id}>
+                      {po.nome}
+                    </option>
+                  ))}
+                </select>
+              </label>
               <PulsanteInvio className="rounded-lg bg-emerald-700 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-800 sm:col-span-2">
                 Crea utente
               </PulsanteInvio>
@@ -178,6 +197,19 @@ export default async function MaestrePage() {
                     />
                     Ore di lavoro
                   </label>
+                  <select
+                    name="profilo_orario_id"
+                    defaultValue={p.profilo_orario_id ?? ''}
+                    aria-label="Profilo orario"
+                    className="rounded-lg border border-stone-300 px-2 py-1 text-xs outline-none focus:border-stone-500"
+                  >
+                    <option value="">Nessun profilo orario</option>
+                    {profiliOrari?.map((po) => (
+                      <option key={po.id} value={po.id}>
+                        {po.nome}
+                      </option>
+                    ))}
+                  </select>
                   <PulsanteInvio className="rounded-lg bg-emerald-700 px-3 py-1 text-xs font-medium text-white hover:bg-emerald-800">
                     Aggiorna
                   </PulsanteInvio>

--- a/app/admin/profili-orari/[id]/page.tsx
+++ b/app/admin/profili-orari/[id]/page.tsx
@@ -1,0 +1,62 @@
+import { redirect } from 'next/navigation';
+import { NavHeader } from '@/components/NavHeader';
+import { FormConEsito } from '@/components/FormConEsito';
+import { PulsanteInvio } from '@/components/PulsanteInvio';
+import { ConfermaAzione } from '@/components/ConfermaAzione';
+import { CampiOreSettimana } from '@/components/CampiOreSettimana';
+import { requireAdmin } from '@/lib/auth';
+import { totaleOreSettimanali } from '@/lib/profiliOrari';
+import { aggiornaProfiloOrario, eliminaProfiloOrario } from '../actions';
+
+export const dynamic = 'force-dynamic';
+
+export default async function ProfiloOrarioDettaglioPage({ params }: { params: { id: string } }) {
+  const { supabase, user, profilo } = await requireAdmin();
+
+  const { data: profiloOrario } = await supabase
+    .from('profili_orari')
+    .select('id, nome, ore_lunedi, ore_martedi, ore_mercoledi, ore_giovedi, ore_venerdi')
+    .eq('id', params.id)
+    .maybeSingle();
+
+  if (!profiloOrario) redirect('/admin/profili-orari');
+
+  return (
+    <>
+      <NavHeader nome={profilo?.nome || user.email || ''} ruolo={profilo?.ruolo ?? null} />
+      <main className="mx-auto max-w-2xl space-y-6 px-4 py-8">
+        <a href="/admin/profili-orari" className="text-sm text-stone-600 hover:text-stone-900">
+          ← Torna ai profili orari
+        </a>
+
+        <h1 className="text-lg font-medium">Modifica profilo orario</h1>
+
+        <FormConEsito
+          action={aggiornaProfiloOrario}
+          className="space-y-2 rounded-xl border border-stone-200 bg-white p-4 shadow-sm"
+        >
+          <input type="hidden" name="profilo_id" value={profiloOrario.id} />
+          <input
+            name="nome"
+            required
+            defaultValue={profiloOrario.nome}
+            placeholder="Nome (es. 35 ore settimanali)"
+            className="w-full rounded-lg border border-stone-300 px-3 py-2 text-sm outline-none focus:border-stone-500"
+          />
+          <CampiOreSettimana valori={profiloOrario} />
+          <p className="text-sm text-stone-600">Totale: {totaleOreSettimanali(profiloOrario)}h/settimana</p>
+          <PulsanteInvio className="rounded-lg bg-emerald-700 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-800">
+            Salva modifiche
+          </PulsanteInvio>
+        </FormConEsito>
+
+        <ConfermaAzione
+          azione={eliminaProfiloOrario}
+          campiNascosti={{ profilo_id: profiloOrario.id }}
+          etichetta="Elimina profilo orario"
+          messaggioConferma="Confermi l'eliminazione? Gli utenti a cui è assegnato resteranno senza profilo orario."
+        />
+      </main>
+    </>
+  );
+}

--- a/app/admin/profili-orari/actions.ts
+++ b/app/admin/profili-orari/actions.ts
@@ -1,0 +1,101 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { requireAdmin } from '@/lib/auth';
+import type { EsitoAzione } from '@/components/FormConEsito';
+
+// Campi condivisi da creazione e modifica di un profilo orario
+// (specs/54 - profili-orari.md). Numeri non validi (vuoto, negativo,
+// non numerico) diventano 0 — coerente con "ore non previste quel
+// giorno", non un errore da segnalare.
+function campiProfiloOrario(formData: FormData) {
+  const ore = (nome: string) => {
+    const valore = Number(formData.get(nome));
+    return Number.isFinite(valore) && valore >= 0 ? valore : 0;
+  };
+
+  return {
+    nome: ((formData.get('nome') as string) || '').trim(),
+    oreLunedi: ore('ore_lunedi'),
+    oreMartedi: ore('ore_martedi'),
+    oreMercoledi: ore('ore_mercoledi'),
+    oreGiovedi: ore('ore_giovedi'),
+    oreVenerdi: ore('ore_venerdi'),
+  };
+}
+
+export async function creaProfiloOrario(_stato: EsitoAzione, formData: FormData): Promise<EsitoAzione> {
+  const { supabase } = await requireAdmin();
+  const { nome, oreLunedi, oreMartedi, oreMercoledi, oreGiovedi, oreVenerdi } = campiProfiloOrario(formData);
+
+  if (!nome) {
+    return { ok: false, messaggio: 'Inserisci un nome per il profilo orario.' };
+  }
+
+  const { error } = await supabase.from('profili_orari').insert({
+    nome,
+    ore_lunedi: oreLunedi,
+    ore_martedi: oreMartedi,
+    ore_mercoledi: oreMercoledi,
+    ore_giovedi: oreGiovedi,
+    ore_venerdi: oreVenerdi,
+  });
+  if (error) {
+    return { ok: false, messaggio: 'Impossibile creare il profilo orario.', dettaglio: error.message };
+  }
+
+  revalidatePath('/admin/profili-orari');
+  revalidatePath('/admin/maestre');
+  return { ok: true };
+}
+
+// specs/54 - profili-orari.md, scenario "modificare un profilo orario".
+export async function aggiornaProfiloOrario(_stato: EsitoAzione, formData: FormData): Promise<EsitoAzione> {
+  const { supabase } = await requireAdmin();
+  const profiloId = formData.get('profilo_id') as string;
+  const { nome, oreLunedi, oreMartedi, oreMercoledi, oreGiovedi, oreVenerdi } = campiProfiloOrario(formData);
+
+  if (!profiloId || !nome) {
+    return { ok: false, messaggio: 'Inserisci un nome per il profilo orario.' };
+  }
+
+  const { error } = await supabase
+    .from('profili_orari')
+    .update({
+      nome,
+      ore_lunedi: oreLunedi,
+      ore_martedi: oreMartedi,
+      ore_mercoledi: oreMercoledi,
+      ore_giovedi: oreGiovedi,
+      ore_venerdi: oreVenerdi,
+    })
+    .eq('id', profiloId);
+  if (error) {
+    return { ok: false, messaggio: 'Impossibile aggiornare il profilo orario.', dettaglio: error.message };
+  }
+
+  revalidatePath(`/admin/profili-orari/${profiloId}`);
+  revalidatePath('/admin/profili-orari');
+  return { ok: true };
+}
+
+// specs/54 - profili-orari.md, scenario "eliminare un profilo orario":
+// gli utenti a cui era assegnato restano semplicemente senza profilo
+// (on delete set null sulla colonna profili.profilo_orario_id, vedi
+// supabase/migrations/0024_profili_orari.sql) — nessun controllo di
+// "profilo in uso" da fare qui.
+export async function eliminaProfiloOrario(_stato: EsitoAzione, formData: FormData): Promise<EsitoAzione> {
+  const { supabase } = await requireAdmin();
+  const profiloId = formData.get('profilo_id') as string;
+  if (!profiloId) return { ok: false, messaggio: 'Profilo orario non valido.' };
+
+  const { error } = await supabase.from('profili_orari').delete().eq('id', profiloId);
+  if (error) {
+    return { ok: false, messaggio: 'Impossibile eliminare il profilo orario.', dettaglio: error.message };
+  }
+
+  revalidatePath('/admin/profili-orari');
+  revalidatePath('/admin/maestre');
+  redirect('/admin/profili-orari');
+}

--- a/app/admin/profili-orari/page.tsx
+++ b/app/admin/profili-orari/page.tsx
@@ -1,0 +1,71 @@
+import Link from 'next/link';
+import { NavHeader } from '@/components/NavHeader';
+import { FormConEsito } from '@/components/FormConEsito';
+import { PulsanteInvio } from '@/components/PulsanteInvio';
+import { CampiOreSettimana } from '@/components/CampiOreSettimana';
+import { requireAdmin } from '@/lib/auth';
+import { totaleOreSettimanali } from '@/lib/profiliOrari';
+import { creaProfiloOrario } from './actions';
+
+export const dynamic = 'force-dynamic';
+
+export default async function ProfiliOrariPage() {
+  const { supabase, user, profilo } = await requireAdmin();
+
+  const { data: profiliOrari } = await supabase
+    .from('profili_orari')
+    .select('id, nome, ore_lunedi, ore_martedi, ore_mercoledi, ore_giovedi, ore_venerdi')
+    .order('nome');
+
+  return (
+    <>
+      <NavHeader nome={profilo?.nome || user.email || ''} ruolo={profilo?.ruolo ?? null} />
+      <main className="mx-auto max-w-2xl space-y-6 px-4 py-8">
+        <div>
+          <h1 className="text-lg font-medium">Profili orari</h1>
+          <p className="mt-1 text-sm text-stone-600">
+            Orari tipo settimanali (ore previste lunedì-venerdì) da assegnare al personale
+            abilitato al report ore, da <a href="/admin/maestre" className="underline">Utenti</a>.
+            Sabato e domenica non sono previsti: l&apos;asilo è chiuso ogni weekend.
+          </p>
+        </div>
+
+        <FormConEsito
+          action={creaProfiloOrario}
+          resetSuOk
+          className="space-y-2 rounded-xl border border-stone-200 bg-white p-4 shadow-sm"
+        >
+          <input
+            name="nome"
+            required
+            placeholder="Nome (es. 35 ore settimanali)"
+            className="w-full rounded-lg border border-stone-300 px-3 py-2 text-sm outline-none focus:border-stone-500"
+          />
+          <CampiOreSettimana />
+          <PulsanteInvio className="rounded-lg bg-emerald-700 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-800">
+            Crea profilo orario
+          </PulsanteInvio>
+        </FormConEsito>
+
+        <ul className="space-y-2">
+          {profiliOrari?.map((p) => (
+            <li key={p.id}>
+              <Link
+                href={`/admin/profili-orari/${p.id}`}
+                className="flex items-center justify-between rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm shadow-sm hover:bg-stone-50"
+              >
+                <span>
+                  {p.nome} <span className="text-stone-600">— {totaleOreSettimanali(p)}h/settimana</span>
+                </span>
+                <span className="text-xs text-stone-500">Modifica</span>
+              </Link>
+            </li>
+          ))}
+          {!profiliOrari?.length && (
+            <li className="text-sm text-stone-600">Nessun profilo orario ancora creato.</li>
+          )}
+        </ul>
+      </main>
+    </>
+  );
+}

--- a/components/CampiOreSettimana.tsx
+++ b/components/CampiOreSettimana.tsx
@@ -1,0 +1,34 @@
+const GIORNI: { campo: string; etichetta: string }[] = [
+  { campo: 'ore_lunedi', etichetta: 'Lunedì' },
+  { campo: 'ore_martedi', etichetta: 'Martedì' },
+  { campo: 'ore_mercoledi', etichetta: 'Mercoledì' },
+  { campo: 'ore_giovedi', etichetta: 'Giovedì' },
+  { campo: 'ore_venerdi', etichetta: 'Venerdì' },
+];
+
+// I 5 campi "ore previste" (lunedì-venerdì) di un profilo orario
+// (specs/54 - profili-orari.md), condivisi da creazione
+// (app/admin/profili-orari/page.tsx) e modifica
+// (app/admin/profili-orari/[id]/page.tsx) per non duplicare gli stessi 5
+// input in due posti (CLAUDE.md, sezione jscpd). `valori` assente (form
+// di creazione) parte da 0 su ogni giorno.
+export function CampiOreSettimana({ valori }: { valori?: Partial<Record<string, number | string>> }) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {GIORNI.map((g) => (
+        <label key={g.campo} className="flex flex-col text-xs text-stone-600">
+          {g.etichetta}
+          <input
+            name={g.campo}
+            type="number"
+            min={0}
+            step={0.5}
+            defaultValue={valori?.[g.campo] ?? 0}
+            aria-label={g.etichetta}
+            className="mt-1 w-16 rounded-lg border border-stone-300 px-2 py-1 text-sm outline-none focus:border-stone-500"
+          />
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/components/NavHeader.tsx
+++ b/components/NavHeader.tsx
@@ -30,6 +30,9 @@ export function NavHeader({
               <Link href="/admin/calendario" className="text-sm text-stone-600 hover:text-emerald-700">
                 Calendario scolastico
               </Link>
+              <Link href="/admin/profili-orari" className="text-sm text-stone-600 hover:text-emerald-700">
+                Profili orari
+              </Link>
             </>
           )}
         </div>

--- a/e2e/54-profili-orari.spec.ts
+++ b/e2e/54-profili-orari.spec.ts
@@ -1,0 +1,216 @@
+// Requisito: specs/54 - profili-orari.md
+//
+// ATTENZIONE: questi test creano/modificano/eliminano davvero profili
+// orari (e li assegnano all'account admin di test) sul progetto
+// Supabase di test — vedi la nota in 53-calendario-scolastico.spec.ts.
+// Ogni profilo creato viene eliminato dallo stesso test, e l'assegnazione
+// sull'account admin viene ripristinata a "Nessun profilo orario"
+// (try/finally, stesso pattern di 17-ore-di-lavoro.spec.ts).
+import { test, expect } from '@playwright/test';
+import { hasCredenziali, nessunaViolazioneA11yGrave, statoAutenticazione } from './helpers';
+
+test.describe('54 — Profili orari', () => {
+  test.describe('come admin', () => {
+    test.use({ storageState: statoAutenticazione('admin') });
+
+    test.beforeEach(async ({ page }) => {
+      test.skip(!hasCredenziali('admin'), 'richiede E2E_ADMIN_EMAIL/PASSWORD');
+    });
+
+    test('/admin/profili-orari: elementi presenti + accessibilità', async ({ page }) => {
+      await page.goto('/admin/profili-orari');
+      await expect(page.getByRole('heading', { name: 'Profili orari' })).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Crea profilo orario' })).toBeVisible();
+      await nessunaViolazioneA11yGrave(page);
+    });
+
+    test('creare un profilo orario lo mostra in elenco con il totale settimanale', async ({ page }) => {
+      const nome = `E2E 35 ore ${Date.now()}`;
+
+      await page.goto('/admin/profili-orari');
+      await page.getByPlaceholder('Nome (es. 35 ore settimanali)').fill(nome);
+      await page.getByLabel('Lunedì').fill('7');
+      await page.getByLabel('Martedì').fill('7');
+      await page.getByLabel('Mercoledì').fill('7');
+      await page.getByLabel('Giovedì').fill('7');
+      await page.getByLabel('Venerdì').fill('7');
+      await page.getByRole('button', { name: 'Crea profilo orario' }).click();
+
+      const riga = page.getByText(nome, { exact: false });
+      await expect(riga).toBeVisible({ timeout: 20_000 });
+      await expect(page.getByText(/35\s*h\/settimana/)).toBeVisible();
+
+      // Pulizia.
+      await riga.click();
+      await page.waitForURL(/\/admin\/profili-orari\/.+/);
+      await page.getByRole('button', { name: 'Elimina profilo orario' }).click();
+      await page.getByRole('button', { name: 'Sì' }).click();
+      await page.waitForURL('/admin/profili-orari');
+    });
+
+    test('modificare un profilo orario aggiorna nome, ore e totale', async ({ page }) => {
+      const nome = `E2E modifica ${Date.now()}`;
+
+      await page.goto('/admin/profili-orari');
+      await page.getByPlaceholder('Nome (es. 35 ore settimanali)').fill(nome);
+      await page.getByLabel('Lunedì').fill('4');
+      await page.getByLabel('Martedì').fill('4');
+      await page.getByLabel('Mercoledì').fill('4');
+      await page.getByLabel('Giovedì').fill('4');
+      await page.getByLabel('Venerdì').fill('4');
+      await page.getByRole('button', { name: 'Crea profilo orario' }).click();
+
+      const riga = page.getByText(nome, { exact: false });
+      await expect(riga).toBeVisible({ timeout: 20_000 });
+      await riga.click();
+      await page.waitForURL(/\/admin\/profili-orari\/.+/);
+      await nessunaViolazioneA11yGrave(page);
+
+      await page.getByLabel('Venerdì').fill('2');
+      await page.getByRole('button', { name: 'Salva modifiche' }).click();
+      await expect(page.getByText(/18\s*h\/settimana/)).toBeVisible({ timeout: 20_000 });
+
+      // Resta salvato anche dopo un ricaricamento.
+      await page.reload();
+      await expect(page.getByLabel('Venerdì')).toHaveValue('2');
+
+      // Pulizia.
+      await page.getByRole('button', { name: 'Elimina profilo orario' }).click();
+      await page.getByRole('button', { name: 'Sì' }).click();
+    });
+
+    test('eliminare un profilo orario lo rimuove dall\'elenco', async ({ page }) => {
+      const nome = `E2E elimina ${Date.now()}`;
+
+      await page.goto('/admin/profili-orari');
+      await page.getByPlaceholder('Nome (es. 35 ore settimanali)').fill(nome);
+      await page.getByLabel('Lunedì').fill('3');
+      await page.getByLabel('Martedì').fill('3');
+      await page.getByLabel('Mercoledì').fill('3');
+      await page.getByLabel('Giovedì').fill('3');
+      await page.getByLabel('Venerdì').fill('3');
+      await page.getByRole('button', { name: 'Crea profilo orario' }).click();
+
+      const riga = page.getByText(nome, { exact: false });
+      await expect(riga).toBeVisible({ timeout: 20_000 });
+      await riga.click();
+      await page.waitForURL(/\/admin\/profili-orari\/.+/);
+
+      await page.getByRole('button', { name: 'Elimina profilo orario' }).click();
+      await page.getByRole('button', { name: 'Sì' }).click();
+      await page.waitForURL('/admin/profili-orari');
+      await expect(page.getByText(nome, { exact: false })).toHaveCount(0);
+    });
+
+    test('assegnare/rimuovere un profilo orario a un utente esistente, e il profilo eliminato lo svuota', async ({
+      page,
+    }) => {
+      const nome = `E2E assegna ${Date.now()}`;
+
+      await page.goto('/admin/profili-orari');
+      await page.getByPlaceholder('Nome (es. 35 ore settimanali)').fill(nome);
+      await page.getByLabel('Lunedì').fill('5');
+      await page.getByLabel('Martedì').fill('5');
+      await page.getByLabel('Mercoledì').fill('5');
+      await page.getByLabel('Giovedì').fill('5');
+      await page.getByLabel('Venerdì').fill('5');
+      await page.getByRole('button', { name: 'Crea profilo orario' }).click();
+      await expect(page.getByText(nome, { exact: false })).toBeVisible({ timeout: 20_000 });
+
+      try {
+        await page.goto('/admin/maestre');
+        const rigaPropria = page.locator('li', { hasText: process.env.E2E_ADMIN_EMAIL! });
+        await rigaPropria.getByLabel('Profilo orario').selectOption({ label: nome });
+        await rigaPropria.getByRole('button', { name: 'Aggiorna' }).click();
+        await page.waitForTimeout(1000);
+        await page.reload();
+        // L'opzione selezionata resta quella scelta anche dopo il
+        // ricaricamento (non torna a "Nessun profilo orario").
+        await expect(
+          page.locator('li', { hasText: process.env.E2E_ADMIN_EMAIL! }).getByLabel('Profilo orario').locator('option:checked')
+        ).toHaveText(nome);
+
+        // Rimozione dell'assegnazione.
+        const rigaDaAggiornare = page.locator('li', { hasText: process.env.E2E_ADMIN_EMAIL! });
+        await rigaDaAggiornare.getByLabel('Profilo orario').selectOption({ label: 'Nessun profilo orario' });
+        await rigaDaAggiornare.getByRole('button', { name: 'Aggiorna' }).click();
+        await page.waitForTimeout(1000);
+        await page.reload();
+        await expect(
+          page.locator('li', { hasText: process.env.E2E_ADMIN_EMAIL! }).getByLabel('Profilo orario')
+        ).toHaveValue('');
+      } finally {
+        // Pulizia del profilo: elimino il profilo, l'utente eventualmente
+        // ancora assegnato resta semplicemente senza profilo (specs/54).
+        await page.goto('/admin/profili-orari');
+        const rigaProfilo = page.getByText(nome, { exact: false });
+        if ((await rigaProfilo.count()) > 0) {
+          await rigaProfilo.click();
+          await page.waitForURL(/\/admin\/profili-orari\/.+/);
+          await page.getByRole('button', { name: 'Elimina profilo orario' }).click();
+          await page.getByRole('button', { name: 'Sì' }).click();
+        }
+      }
+    });
+
+    test('creare un utente scegliendo subito un profilo orario', async ({ page }) => {
+      const nomeProfilo = `E2E creazione ${Date.now()}`;
+      const email = `e2e-profilo-orario-${Date.now()}@example.com`;
+
+      await page.goto('/admin/profili-orari');
+      await page.getByPlaceholder('Nome (es. 35 ore settimanali)').fill(nomeProfilo);
+      await page.getByLabel('Lunedì').fill('6');
+      await page.getByLabel('Martedì').fill('6');
+      await page.getByLabel('Mercoledì').fill('6');
+      await page.getByLabel('Giovedì').fill('6');
+      await page.getByLabel('Venerdì').fill('6');
+      await page.getByRole('button', { name: 'Crea profilo orario' }).click();
+      await expect(page.getByText(nomeProfilo, { exact: false })).toBeVisible({ timeout: 20_000 });
+
+      try {
+        await page.goto('/admin/maestre');
+        const formCreazione = page.locator('form', { has: page.getByRole('button', { name: 'Crea utente' }) });
+
+        await page.getByPlaceholder('Nome').first().fill('Prova');
+        await page.getByPlaceholder('Cognome').first().fill('ProfiloOrario');
+        await page.getByPlaceholder('Email').fill(email);
+        await page.getByPlaceholder('Telefono').first().fill('3331234567');
+        await page.getByLabel('Password', { exact: true }).fill('PasswordE2E!1');
+        await page.getByLabel('Conferma password').fill('PasswordE2E!1');
+        await formCreazione.getByLabel('Profilo orario').selectOption({ label: nomeProfilo });
+        await page.getByRole('button', { name: 'Crea utente' }).click();
+
+        const riga = page.getByText(email, { exact: false }).locator('..');
+        await expect(riga).toBeVisible({ timeout: 20_000 });
+        await expect(riga.getByLabel('Profilo orario')).not.toHaveValue('');
+
+        await riga.getByRole('button', { name: 'Elimina utente' }).click();
+        await page.waitForTimeout(1000);
+        await expect(page.getByText(email, { exact: false })).toHaveCount(0);
+      } finally {
+        await page.goto('/admin/profili-orari');
+        const rigaProfilo = page.getByText(nomeProfilo, { exact: false });
+        if ((await rigaProfilo.count()) > 0) {
+          await rigaProfilo.click();
+          await page.waitForURL(/\/admin\/profili-orari\/.+/);
+          await page.getByRole('button', { name: 'Elimina profilo orario' }).click();
+          await page.getByRole('button', { name: 'Sì' }).click();
+        }
+      }
+    });
+
+    test('accesso negato a chi non è admin', async ({ browser }) => {
+      for (const ruolo of ['maestra', 'assistente', 'genitore'] as const) {
+        test.skip(!hasCredenziali(ruolo), `richiede E2E_${ruolo.toUpperCase()}_EMAIL/PASSWORD`);
+        const stato = statoAutenticazione(ruolo);
+        test.skip(!stato, `sessione non disponibile per ${ruolo}`);
+
+        const context = await browser.newContext({ storageState: stato });
+        const page = await context.newPage();
+        await page.goto('/admin/profili-orari');
+        await page.waitForURL('/dashboard', { timeout: 20_000 });
+        await context.close();
+      }
+    });
+  });
+});

--- a/lib/profiliOrari.test.ts
+++ b/lib/profiliOrari.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { totaleOreSettimanali } from './profiliOrari';
+
+// totaleOreSettimanali è pura (nessun I/O): copre i casi limite del
+// calcolo del totale ore settimanali di specs/54 - profili-orari.md.
+describe('totaleOreSettimanali', () => {
+  it('35 ore settimanali: 7 ore per 5 giorni', () => {
+    const profilo = { ore_lunedi: 7, ore_martedi: 7, ore_mercoledi: 7, ore_giovedi: 7, ore_venerdi: 7 };
+    expect(totaleOreSettimanali(profilo)).toBe(35);
+  });
+
+  it('32 ore settimanali: 4 giorni a 7 ore, 1 giorno a 4 ore', () => {
+    const profilo = { ore_lunedi: 7, ore_martedi: 7, ore_mercoledi: 7, ore_giovedi: 7, ore_venerdi: 4 };
+    expect(totaleOreSettimanali(profilo)).toBe(32);
+  });
+
+  it('assistente a 3 ore al giorno: 15 ore settimanali', () => {
+    const profilo = { ore_lunedi: 3, ore_martedi: 3, ore_mercoledi: 3, ore_giovedi: 3, ore_venerdi: 3 };
+    expect(totaleOreSettimanali(profilo)).toBe(15);
+  });
+
+  it('somma anche mezz\'ore (decimali) correttamente', () => {
+    const profilo = { ore_lunedi: 7.5, ore_martedi: 7.5, ore_mercoledi: 7.5, ore_giovedi: 7.5, ore_venerdi: 4.5 };
+    expect(totaleOreSettimanali(profilo)).toBe(34.5);
+  });
+
+  it('un profilo con tutti i giorni a zero ha totale zero', () => {
+    const profilo = { ore_lunedi: 0, ore_martedi: 0, ore_mercoledi: 0, ore_giovedi: 0, ore_venerdi: 0 };
+    expect(totaleOreSettimanali(profilo)).toBe(0);
+  });
+
+  it('un giorno non lavorato (0 ore) in mezzo agli altri', () => {
+    const profilo = { ore_lunedi: 6, ore_martedi: 6, ore_mercoledi: 0, ore_giovedi: 6, ore_venerdi: 6 };
+    expect(totaleOreSettimanali(profilo)).toBe(24);
+  });
+});

--- a/lib/profiliOrari.ts
+++ b/lib/profiliOrari.ts
@@ -1,0 +1,23 @@
+// I campi ore_* arrivano da una colonna `numeric` di Postgres via
+// PostgREST: a seconda della versione può essere già un number oppure
+// una stringa (per non perdere precisione) — number | string accetta
+// entrambi, Number(...) sotto normalizza.
+export type ProfiloOrario = {
+  ore_lunedi: number | string;
+  ore_martedi: number | string;
+  ore_mercoledi: number | string;
+  ore_giovedi: number | string;
+  ore_venerdi: number | string;
+};
+
+// Totale ore settimanali di un profilo orario (specs/54 -
+// profili-orari.md): somma dei 5 giorni feriali — sabato e domenica
+// sono chiusura implicita (specs/53 - calendario-scolastico.md), quindi
+// non previsti nel profilo. Non è un campo salvato a parte da tenere
+// sincronizzato a mano: chi mostra il profilo (elenco, scheda) lo
+// ricalcola sempre da qui. Funzione pura, nessun I/O.
+export function totaleOreSettimanali(profilo: ProfiloOrario): number {
+  return [profilo.ore_lunedi, profilo.ore_martedi, profilo.ore_mercoledi, profilo.ore_giovedi, profilo.ore_venerdi]
+    .map(Number)
+    .reduce((totale, ore) => totale + ore, 0);
+}

--- a/lib/versione.ts
+++ b/lib/versione.ts
@@ -4,5 +4,5 @@
 // ora, minuti e secondi (fuso Europe/Rome, non UTC — coerente con
 // lib/date.ts), non solo la data: utile per distinguere più rilasci
 // fatti nello stesso giorno.
-export const VERSIONE_APP = '0.13.0';
-export const DATA_BUILD = '2026-08-29 21:01:00';
+export const VERSIONE_APP = '0.14.0';
+export const DATA_BUILD = '2026-08-31 09:21:39';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "girasole",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "girasole",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "dependencies": {
         "@supabase/ssr": "^0.5.1",
         "@supabase/supabase-js": "^2.45.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "girasole",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/specs/00 - overview.md
+++ b/specs/00 - overview.md
@@ -70,6 +70,10 @@ della maestra, `5x` amministrazione.
 - [53 - calendario-scolastico.md](53%20-%20calendario-scolastico.md) —
   giorni di chiusura scolastica (admin) e blocco di presenze/pasti nei
   giorni chiusi, weekend inclusi
+- [54 - profili-orari.md](54%20-%20profili-orari.md) — definizione
+  (admin) di profili orari settimanali e loro assegnazione al
+  personale, propedeutica alla futura registrazione delle ore di
+  lavoro
 
 Quando si aggiunge un requisito nuovo che non rientra in nessuno scenario
 esistente, creare un nuovo file numerato in questa cartella (seguendo la

--- a/specs/03 - utenti-e-ruoli.md
+++ b/specs/03 - utenti-e-ruoli.md
@@ -29,6 +29,9 @@ utenti da `/admin/maestre`.
 - **abilitazione al report ore di lavoro** — checkbox, falsa di default;
   decide se l'utente vede la sezione "Ore di lavoro" in dashboard (vedi
   [17 - ore-di-lavoro.md](17%20-%20ore-di-lavoro.md))
+- **profilo orario** — menu a tendina opzionale, tra i profili definiti
+  dall'admin (vedi [54 - profili-orari.md](54%20-%20profili-orari.md)),
+  indipendente dall'abilitazione al report ore
 
 ## Ruoli
 Un utente ha uno e un solo ruolo, tra:

--- a/specs/17 - ore-di-lavoro.md
+++ b/specs/17 - ore-di-lavoro.md
@@ -68,3 +68,7 @@ l'accesso alla sezione, non la sua funzione
   registrate (form di inserimento, calcolo ore/assenze, riepiloghi,
   export, eventuali approvazioni) — qui si abilita solo l'accesso al
   punto d'ingresso della sezione.
+- L'admin può anche definire un "orario tipo" settimanale (ore previste
+  per giorno) e assegnarlo a ciascuna persona, indipendentemente
+  dall'abilitazione descritta qui — vedi
+  [54 - profili-orari.md](54%20-%20profili-orari.md).

--- a/specs/54 - profili-orari.md
+++ b/specs/54 - profili-orari.md
@@ -1,0 +1,95 @@
+# 54 — Profili orari
+
+## Attori
+Admin.
+
+## Obiettivo
+Dare all'admin uno strumento per definire, in un pannello dedicato,
+degli "orari tipo" (es. "35 ore settimanali", "32 ore settimanali",
+"Assistente 3h/giorno") con le ore previste per ciascun giorno feriale,
+e assegnarne uno a ciascuna persona — così da avere, per ogni membro del
+personale abilitato al report ore (vedi
+[17 - ore-di-lavoro.md](17%20-%20ore-di-lavoro.md)), un riferimento di
+quante ore dovrebbe lavorare ogni giorno. **Come** questo riferimento
+verrà poi usato (confronto con le ore segnate, calcolo di
+straordinari/assenze, riepiloghi) è fuori scope, sarà definito in una
+fase successiva.
+
+## Scenario: creare un profilo orario
+Dato che sono autenticato come admin
+Quando su `/admin/profili-orari` inserisco un nome (es. "35 ore
+settimanali") e le ore previste per lunedì, martedì, mercoledì, giovedì
+e venerdì, e confermo
+Allora il profilo compare nell'elenco, con il totale ore settimanali
+calcolato automaticamente (somma dei 5 giorni)
+
+## Scenario: modificare un profilo orario
+Dato che ho aperto la scheda di dettaglio di un profilo orario esistente
+Quando trovo un form con nome e ore pre-caricati, modifico uno o più
+valori e confermo
+Allora i nuovi dati sono salvati e restano visibili riaprendo la scheda,
+totale settimanale ricalcolato di conseguenza
+
+## Scenario: eliminare un profilo orario
+Dato che sono sulla scheda di dettaglio di un profilo orario
+Quando premo "Elimina" e confermo
+Allora il profilo scompare dall'elenco
+E ogni utente a cui era assegnato resta con i propri dati invariati, ma
+senza più un profilo assegnato ("Nessun profilo orario") — l'eliminazione
+non è mai bloccata dal fatto che il profilo sia in uso
+
+## Scenario: assegnare un profilo orario a un utente esistente
+Dato che un utente esiste già
+Quando su `/admin/maestre` scelgo un profilo orario dal menu "Profilo
+orario" per quell'utente e premo "Aggiorna"
+Allora il profilo scelto è salvato e resta selezionato riaprendo la
+pagina
+
+## Scenario: scegliere subito un profilo orario in fase di creazione utente
+Quando su `/admin/maestre` creo un nuovo utente e scelgo un profilo
+orario dal menu "Profilo orario" prima di confermare
+Allora l'utente viene creato con quel profilo già assegnato
+
+## Scenario: rimuovere l'assegnazione di un profilo orario
+Quando su `/admin/maestre` scelgo "Nessun profilo orario" per un utente
+che ne aveva uno assegnato, e premo "Aggiorna"
+Allora quell'utente risulta senza profilo orario assegnato
+
+## Scenario: accesso negato a chi non è admin
+Dato che sono autenticato come maestra, assistente o genitore
+Quando provo ad aprire `/admin/profili-orari`
+Allora vengo reindirizzato alla dashboard
+
+## Regole
+- Un profilo orario ha un nome libero (`profili_orari.nome`, nessun
+  formato imposto: l'admin può scrivere "35 ore settimanali" o
+  qualunque altra etichetta gli sia comoda) e un numero di ore per
+  ciascuno dei 5 giorni feriali (lunedì-venerdì): numeri non negativi,
+  fino a due decimali (es. 7, 7.5). Sabato e domenica non sono previsti:
+  l'asilo è chiuso implicitamente ogni weekend (vedi
+  [53 - calendario-scolastico.md](53%20-%20calendario-scolastico.md)).
+- Il totale ore settimanali mostrato in elenco e nella scheda è sempre
+  calcolato come somma dei 5 giorni, non un campo salvato a parte da
+  tenere sincronizzato a mano.
+- L'assegnazione profilo↔utente (`profili.profilo_orario_id`) e
+  l'abilitazione al report ore (`profili.abilitato_ore_lavoro`, vedi
+  [17 - ore-di-lavoro.md](17%20-%20ore-di-lavoro.md)) sono due controlli
+  indipendenti: il selettore "Profilo orario" è disponibile per
+  qualunque utente su `/admin/maestre`, abilitato o no. Assegnare un
+  profilo non abilita automaticamente il report ore, e abilitare il
+  report ore non richiede necessariamente un profilo già assegnato —
+  in quel caso l'utente è abilitato ma senza profilo, stato valido e
+  non bloccante in questa fase.
+- Solo un profilo con ruolo `admin` può creare, modificare, eliminare o
+  assegnare profili orari (RLS in
+  `supabase/migrations/0024_profili_orari.sql`); nessun altro ruolo li
+  legge in questa fase (non ancora mostrati allo staff, vedi Obiettivo).
+- Eliminare un profilo orario assegnato a uno o più utenti non è
+  bloccato: l'assegnazione di quegli utenti torna semplicemente vuota
+  (`on delete set null`), stesso pattern già usato per
+  `sezioni.anno_scolastico_id` (vedi
+  [04 - data-types.md](04%20-%20data-types.md)).
+- Fuori scope in questa fase: come i profili orari verranno
+  effettivamente usati (form di inserimento ore/assenze, confronto con
+  le ore segnate, calcolo di straordinari o assenze, riepiloghi,
+  export) — qui si definiscono e si assegnano solo i profili.

--- a/supabase/migrations/0024_profili_orari.sql
+++ b/supabase/migrations/0024_profili_orari.sql
@@ -1,0 +1,40 @@
+-- Girasole — Profili orari (specs/54 - profili-orari.md): "orari tipo"
+-- settimanali (ore previste lunedì-venerdì) che l'admin definisce in un
+-- pannello dedicato e assegna al personale, indipendentemente
+-- dall'abilitazione al report ore (specs/17 -
+-- ore-di-lavoro.md). Solo la definizione/assegnazione dei profili in
+-- questa fase: come verranno effettivamente usati resta fuori scope.
+--
+-- Incolla questo file nel SQL Editor di Supabase (dopo
+-- 0023_ore_lavoro_abilitazione.sql) ed eseguilo una volta sola.
+
+create table public.profili_orari (
+  id uuid primary key default gen_random_uuid(),
+  nome text not null,
+  ore_lunedi numeric(4, 2) not null default 0,
+  ore_martedi numeric(4, 2) not null default 0,
+  ore_mercoledi numeric(4, 2) not null default 0,
+  ore_giovedi numeric(4, 2) not null default 0,
+  ore_venerdi numeric(4, 2) not null default 0,
+  created_at timestamptz not null default now()
+);
+
+alter table public.profili_orari enable row level security;
+
+-- Solo l'admin, in ogni operazione: è un pannello di configurazione,
+-- non ancora un dato che lo staff deve leggere (specs/54 — "vedremo poi
+-- a cosa serviranno" era la richiesta esplicita dell'utente).
+create policy "profili_orari_admin_all" on public.profili_orari
+  for all using (public.ruolo_corrente() = 'admin')
+  with check (public.ruolo_corrente() = 'admin');
+
+grant select, insert, update, delete on public.profili_orari to authenticated;
+
+-- =========================================================
+-- Assegnazione utente -> profilo orario: al più un profilo per utente,
+-- facoltativo (indipendente da profili.abilitato_ore_lavoro, specs/54).
+-- Se il profilo viene eliminato, l'utente resta senza assegnazione
+-- invece di bloccare l'eliminazione — stesso pattern già usato per
+-- sezioni.anno_scolastico_id (0006_data_types.sql).
+-- =========================================================
+alter table public.profili add column if not exists profilo_orario_id uuid references public.profili_orari(id) on delete set null;


### PR DESCRIPTION
## Summary
- Secondo passo verso le ore di lavoro del personale: l'admin definisce "orari tipo" settimanali (nome + ore lun-ven, es. "35 ore settimanali", "32 ore settimanali", "Assistente 15h") in un nuovo pannello dedicato `/admin/profili-orari` (elenco+creazione, e `/admin/profili-orari/[id]` per modifica/eliminazione — stesso pattern list+detail di `/admin/calendario`).
- Ogni profilo può essere assegnato a un utente dal menu "Profilo orario" (opzionale) aggiunto su `/admin/maestre`, sia in creazione sia in modifica — **indipendente** dal checkbox "Ore di lavoro" già esistente (specs/17): sono due controlli separati, scelta esplicita per restare semplici.
- Nuova tabella `profili_orari` e colonna `profili.profilo_orario_id` (`supabase/migrations/0024_profili_orari.sql`, RLS solo admin, `on delete set null` — eliminare un profilo non è mai bloccato, svuota solo l'assegnazione).
- `lib/profiliOrari.ts` (puro): `totaleOreSettimanali` somma i 5 giorni, con unit test. `components/CampiOreSettimana.tsx` evita di duplicare i 5 input ore tra creazione e modifica del profilo.
- Nuovo `specs/54 - profili-orari.md` (in indice su `specs/00`); `specs/17` e `specs/03` aggiornate con riferimenti incrociati.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx next lint`
- [x] `npx vitest run` (150 test, inclusi i 6 nuovi unit test di `lib/profiliOrari.test.ts`)
- [x] `npx jscpd` (nessun nuovo duplicato — i 3 clone segnalati sono preesistenti)
- [ ] `npx playwright test e2e/54-profili-orari.spec.ts` dal tuo ambiente locale (non eseguibile in questo ambiente sandbox — nessun dev server/credenziali Supabase). Copre i 7 scenari di specs/54 (creazione/modifica/eliminazione di un profilo con totale ricalcolato, assegnazione/rimozione a un utente esistente con persistenza dopo reload, profilo scelto già in creazione utente, accesso negato a chi non è admin), incluso axe-core.
- [ ] Rieseguire anche `e2e/03-utenti-e-ruoli.spec.ts` e `e2e/17-ore-di-lavoro.spec.ts` (pagine toccate) dal tuo ambiente locale.

## Da fare dopo il merge
- Applicare `supabase/migrations/0024_profili_orari.sql` nel SQL Editor di Supabase (progetto di test e produzione) — senza, la tabella `profili_orari` e la colonna `profili.profilo_orario_id` non esistono.

---
_Generated by [Claude Code](https://claude.ai/code/session_0165puuH5x8UEN9SYds2KVhF)_