### PR TITLE
Report ore di lavoro: form settimanale, malattia/assenza, conferma (v0.15.0)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1178,10 +1178,83 @@ Due bug segnalati dopo l'uso reale di `/admin/maestre`.
       — senza, la tabella `profili_orari` e la colonna
       `profili.profilo_orario_id` non esistono.
 
+## Report ore di lavoro: form settimanale, malattia/assenza, conferma (v0.15.0)
+- [x] Richiesta dell'utente: terzo passo verso le ore di lavoro del
+      personale. `/dashboard/ore-lavoro` (finora un placeholder,
+      v0.13.0) mostra ora la settimana corrente in forma tabellare (una
+      card per giorno feriale): ore ordinarie precaricate dal profilo
+      orario (v0.14.0) e modificabili, ore straordinarie libere (con
+      motivo obbligatorio), stato "Malattia" (codice obbligatorio) o
+      "Assenza" (nota obbligatoria) in alternativa alle ore. Il
+      personale salva le modifiche e conferma la settimana quando
+      soddisfatto; da quel momento non può più modificarla (solo
+      l'admin può, RLS pronta, interfaccia dedicata fuori scope).
+- [x] Nuovo `specs/18 - report-ore-lavoro.md` (in indice su
+      `specs/00`); `specs/17 - ore-di-lavoro.md` aggiornata a
+      rimandarci per il "come" (non più un placeholder).
+- [x] `supabase/migrations/0025_report_ore_lavoro.sql`: nuove tabelle
+      `ore_lavoro_giorni` (stato/ore/motivo/codice/nota, con check
+      constraint per ciascuna delle tre regole di obbligatorietà) e
+      `ore_lavoro_settimane` (l'esistenza della riga è la conferma,
+      stesso pattern di `report_giornalieri_inviati`, specs/52). RLS:
+      il personale scrive solo le proprie righe e solo se la settimana
+      non è confermata (funzione `settimana_ore_lavoro_confermata`),
+      l'admin sempre. Trigger `impedisci_ore_lavoro_giorno_chiuso`
+      riusa `public.giorno_chiuso` (0022): un giorno di chiusura
+      scolastica non è scrivibile da nessuno, come già per
+      presenze/pasti (specs/53, che rimandava esplicitamente a questa
+      futura funzionalità).
+- [x] `lib/date.ts`: nuove `giornoSettimanaIso` (refactor di `isWeekend`
+      per riusarla) e `giorniLavorativiSettimana` (i 5 giorni
+      lunedì-venerdì della settimana di una data). `lib/oreLavoro.ts`
+      (nuovo, puro): `oreOrdinariePreviste` (precaricamento dal profilo
+      orario), `validaGiornoOreLavoro` (le tre regole di
+      obbligatorietà, azzera ore su malattia/assenza),
+      `totaliSettimanaOreLavoro`. `lib/calendarioScolastico.ts`:
+      `chiusurePerPeriodo` (chiusure su un intervallo, non solo un
+      giorno). `lib/profiliOrari.ts`: `recuperaProfiloOrario`. Unit
+      test in `lib/date.test.ts`, `lib/oreLavoro.test.ts` (23 nuovi
+      test totali).
+- [x] `components/RigaOreLavoro.tsx` (nuovo, client): riga editabile di
+      un giorno, mostra solo i campi pertinenti allo stato scelto
+      (specs/01 - ux.md, "preferire azioni a un tap a form con molti
+      campi") — toggle solo visivo, la sottomissione resta un form
+      nativo lato server. `app/dashboard/ore-lavoro/page.tsx` riscritta
+      (non più un placeholder): card per giorno (editabile o sola
+      lettura se la settimana è confermata, chiusura scolastica se il
+      giorno è chiuso), totale settimanale, pulsante "Conferma
+      settimana" (`components/ConfermaAzione.tsx`, tono neutro). Nuove
+      `app/dashboard/ore-lavoro/actions.ts:salvaSettimanaOreLavoro`
+      (valida tutti i giorni prima di scrivere qualunque cosa, nessun
+      salvataggio parziale su un errore — specs/05) e
+      `confermaSettimanaOreLavoro` (completa i giorni non ancora
+      salvati con i valori precaricati, poi registra la conferma).
+- [x] Verificato: `npx tsc --noEmit`, `npx next lint`, `npx vitest run`
+      (169 test) e `npx jscpd` (3 clone preesistenti, sotto soglia,
+      nessuno nuovo) puliti. Suite e2e Playwright non eseguibile da
+      questo ambiente sandbox (nessun dev server né credenziali
+      Supabase): nuovo `e2e/18-report-ore-lavoro.spec.ts` da verificare
+      con `npx playwright test e2e/18-report-ore-lavoro.spec.ts` (e
+      rieseguire 17) dal tuo ambiente locale. **Nota importante**: quel
+      file non preme mai per davvero "Sì" su "Conferma settimana" —
+      confermare è irreversibile fino al lunedì successivo (nessuna
+      "riapertura" in questa fase) e bloccherebbe la scrittura
+      sull'account di test condiviso per il resto della settimana,
+      stessa cautela già presa per "Pasti comunicati a Rojac"
+      (specs/16). Lo scenario "settimana confermata" si verifica solo
+      se qualcuno l'ha già confermata manualmente questa settimana
+      (altrimenti `test.skip`).
+- [ ] **Da fare da parte tua**: applica
+      `supabase/migrations/0025_report_ore_lavoro.sql` nel SQL Editor
+      di Supabase (test e produzione) prima di usare
+      `/dashboard/ore-lavoro` — senza, la pagina fallisce a leggere/
+      scrivere le tabelle `ore_lavoro_giorni`/`ore_lavoro_settimane`.
+
 ## Backlog — Fase 2/3
 - [ ] Rette mensili e stato pagamento
 - [ ] Portale genitori (UI dedicata)
-- [ ] Ore di lavoro: come il personale segna effettivamente ore
-      lavorate/assenze (form, calcolo, riepiloghi, export), e come i
-      profili orari (v0.14.0) entrano in quel calcolo — questa
-      abilitazione (v0.13.0) è solo il primo passo
+- [ ] Ore di lavoro: interfaccia admin per rivedere/correggere le
+      settimane (confermate o no) di un altro utente — i permessi RLS
+      sono già pronti (v0.15.0), manca solo la pagina
+- [ ] Ore di lavoro: calcolo effettivo di un monte ore/straordinari a
+      partire dai dati registrati (v0.15.0), riepiloghi, export

--- a/app/dashboard/ore-lavoro/actions.ts
+++ b/app/dashboard/ore-lavoro/actions.ts
@@ -1,0 +1,144 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { requireStaff, assicuraAccessoOreLavoro } from '@/lib/auth';
+import { oggi, giorniLavorativiSettimana } from '@/lib/date';
+import { validaGiornoOreLavoro, oreOrdinariePreviste } from '@/lib/oreLavoro';
+import { isGiornoChiuso, chiusurePerPeriodo } from '@/lib/calendarioScolastico';
+import { recuperaProfiloOrario } from '@/lib/profiliOrari';
+import type { EsitoAzione } from '@/components/FormConEsito';
+
+// Nessuna navigazione tra settimane in questa fase (specs/18 -
+// report-ore-lavoro.md, "Fuori scope"): entrambe le azioni scrivono
+// solo sulla settimana corrente, ignorando qualunque valore diverso
+// arrivasse dal campo nascosto settimana_inizio.
+function settimanaCorrenteOSbagliata(formData: FormData): string | null {
+  const settimanaInizio = (formData.get('settimana_inizio') as string) || '';
+  const giorni = giorniLavorativiSettimana(oggi());
+  return settimanaInizio === giorni[0] ? settimanaInizio : null;
+}
+
+// Salva le ore/lo stato di ogni giorno della settimana corrente
+// (specs/18): valida PRIMA tutti i giorni inviati (funzione pura,
+// nessun I/O) e scrive solo se sono tutti validi — nessun salvataggio
+// parziale su un errore (specs/05 - feedback.md).
+export async function salvaSettimanaOreLavoro(_stato: EsitoAzione, formData: FormData): Promise<EsitoAzione> {
+  const { supabase, user, profilo } = await requireStaff({});
+  assicuraAccessoOreLavoro(profilo?.abilitato_ore_lavoro);
+
+  const settimanaInizio = settimanaCorrenteOSbagliata(formData);
+  if (!settimanaInizio) {
+    return { ok: false, messaggio: 'Puoi modificare solo la settimana corrente.' };
+  }
+
+  const giorni = giorniLavorativiSettimana(settimanaInizio);
+  const venerdi = giorni[giorni.length - 1];
+  const chiusure = await chiusurePerPeriodo(supabase, settimanaInizio, venerdi);
+
+  const daScrivere = [];
+  for (const data of giorni) {
+    if (isGiornoChiuso(data, chiusure)) continue;
+
+    const esito = validaGiornoOreLavoro({
+      data,
+      stato: (formData.get(`stato_${data}`) as string) || 'lavorativo',
+      oreOrdinarie: Number(formData.get(`ore_ordinarie_${data}`)) || 0,
+      oreStraordinarie: Number(formData.get(`ore_straordinarie_${data}`)) || 0,
+      motivoStraordinario: (formData.get(`motivo_straordinario_${data}`) as string) || '',
+      codiceMalattia: (formData.get(`codice_malattia_${data}`) as string) || '',
+      notaAssenza: (formData.get(`nota_assenza_${data}`) as string) || '',
+    });
+    if (!esito.ok) {
+      return { ok: false, messaggio: esito.errore };
+    }
+    daScrivere.push(esito.giorno);
+  }
+
+  if (!daScrivere.length) {
+    return { ok: true };
+  }
+
+  const { error } = await supabase.from('ore_lavoro_giorni').upsert(
+    daScrivere.map((g) => ({
+      utente_id: user.id,
+      data: g.data,
+      stato: g.stato,
+      ore_ordinarie: g.oreOrdinarie,
+      ore_straordinarie: g.oreStraordinarie,
+      motivo_straordinario: g.motivoStraordinario,
+      codice_malattia: g.codiceMalattia,
+      nota_assenza: g.notaAssenza,
+      updated_at: new Date().toISOString(),
+    })),
+    { onConflict: 'utente_id,data' }
+  );
+  if (error) {
+    return { ok: false, messaggio: 'Impossibile salvare le ore della settimana.', dettaglio: error.message };
+  }
+
+  revalidatePath('/dashboard/ore-lavoro');
+  return { ok: true };
+}
+
+// Conferma la settimana corrente (specs/18): prima completa con i
+// valori precaricati dal profilo orario ogni giorno non ancora salvato
+// esplicitamente (scenario "confermare la settimana"), poi registra la
+// conferma vera e propria — l'esistenza della riga in
+// ore_lavoro_settimane È la conferma (stesso pattern di
+// report_giornalieri_inviati, specs/52).
+export async function confermaSettimanaOreLavoro(_stato: EsitoAzione, formData: FormData): Promise<EsitoAzione> {
+  const { supabase, user, profilo } = await requireStaff({});
+  assicuraAccessoOreLavoro(profilo?.abilitato_ore_lavoro);
+
+  const settimanaInizio = settimanaCorrenteOSbagliata(formData);
+  if (!settimanaInizio) {
+    return { ok: false, messaggio: 'Puoi confermare solo la settimana corrente.' };
+  }
+
+  const giorni = giorniLavorativiSettimana(settimanaInizio);
+  const venerdi = giorni[giorni.length - 1];
+  const chiusure = await chiusurePerPeriodo(supabase, settimanaInizio, venerdi);
+
+  const { data: esistenti } = await supabase
+    .from('ore_lavoro_giorni')
+    .select('data')
+    .eq('utente_id', user.id)
+    .in('data', giorni);
+  const dateEsistenti = new Set((esistenti ?? []).map((r) => r.data));
+
+  const profiloOrario = await recuperaProfiloOrario(supabase, profilo?.profilo_orario_id);
+
+  const daCompletare = giorni
+    .filter((data) => !isGiornoChiuso(data, chiusure) && !dateEsistenti.has(data))
+    .map((data) => ({
+      utente_id: user.id,
+      data,
+      stato: 'lavorativo',
+      ore_ordinarie: oreOrdinariePreviste(profiloOrario, data),
+      ore_straordinarie: 0,
+    }));
+
+  if (daCompletare.length) {
+    const { error: erroreCompletamento } = await supabase.from('ore_lavoro_giorni').insert(daCompletare);
+    if (erroreCompletamento) {
+      return {
+        ok: false,
+        messaggio: 'Impossibile completare i giorni mancanti prima della conferma.',
+        dettaglio: erroreCompletamento.message,
+      };
+    }
+  }
+
+  const { error } = await supabase
+    .from('ore_lavoro_settimane')
+    .insert({ utente_id: user.id, settimana_inizio: settimanaInizio });
+  if (error) {
+    if (error.code === '23505') {
+      return { ok: false, messaggio: 'Questa settimana risulta già confermata.' };
+    }
+    return { ok: false, messaggio: 'Impossibile confermare la settimana.', dettaglio: error.message };
+  }
+
+  revalidatePath('/dashboard/ore-lavoro');
+  return { ok: true };
+}

--- a/app/dashboard/ore-lavoro/page.tsx
+++ b/app/dashboard/ore-lavoro/page.tsx
@@ -1,31 +1,172 @@
 import { NavHeader } from '@/components/NavHeader';
+import { FormConEsito } from '@/components/FormConEsito';
+import { PulsanteInvio } from '@/components/PulsanteInvio';
+import { ConfermaAzione } from '@/components/ConfermaAzione';
+import { RigaOreLavoro, ETICHETTE_STATO_ORE_LAVORO, type StatoGiornoOreLavoro } from '@/components/RigaOreLavoro';
 import { requireStaff, assicuraAccessoOreLavoro } from '@/lib/auth';
+import { oggi, giorniLavorativiSettimana, giornoSettimanaIso, formattaIntervalloItaliano, formattaDataBreve, formattaDataOraItaliana } from '@/lib/date';
+import { oreOrdinariePreviste, totaliSettimanaOreLavoro } from '@/lib/oreLavoro';
+import { recuperaProfiloOrario } from '@/lib/profiliOrari';
+import { isGiornoChiuso, messaggioChiusura, chiusurePerPeriodo } from '@/lib/calendarioScolastico';
+import { salvaSettimanaOreLavoro, confermaSettimanaOreLavoro } from './actions';
 
 export const dynamic = 'force-dynamic';
 
-// Punto d'ingresso della sezione "Ore di lavoro" (specs/17 -
-// ore-di-lavoro.md): in questa fase abilita solo l'accesso, senza alcuna
-// form — la registrazione vera e propria di ore/assenze è fuori scope,
-// verrà definita in una fase successiva.
+const NOMI_GIORNI: Record<number, string> = {
+  1: 'Lunedì',
+  2: 'Martedì',
+  3: 'Mercoledì',
+  4: 'Giovedì',
+  5: 'Venerdì',
+};
+
+// Sezione "Ore di lavoro" (specs/18 - report-ore-lavoro.md): il
+// personale abilitato (specs/17) registra ore/malattia/assenza per la
+// settimana corrente e la conferma. Una volta confermata, la pagina
+// mostra i dati in sola lettura (nessun campo modificabile).
 export default async function OreLavoroPage() {
-  const { user, profilo, ruolo } = await requireStaff({});
+  const { supabase, user, profilo, ruolo } = await requireStaff({});
   assicuraAccessoOreLavoro(profilo?.abilitato_ore_lavoro);
 
   const nomeVisualizzato = profilo?.nome || user.email || '';
+  const giorni = giorniLavorativiSettimana(oggi());
+  const [lunedi, , , , venerdi] = giorni;
+
+  const [profiloOrario, { data: righeGiorni }, { data: settimana }, chiusure] = await Promise.all([
+    recuperaProfiloOrario(supabase, profilo?.profilo_orario_id),
+    supabase
+      .from('ore_lavoro_giorni')
+      .select('data, stato, ore_ordinarie, ore_straordinarie, motivo_straordinario, codice_malattia, nota_assenza')
+      .eq('utente_id', user.id)
+      .in('data', giorni),
+    supabase
+      .from('ore_lavoro_settimane')
+      .select('confermata_at')
+      .eq('utente_id', user.id)
+      .eq('settimana_inizio', lunedi)
+      .maybeSingle(),
+    chiusurePerPeriodo(supabase, lunedi, venerdi),
+  ]);
+
+  const righePerGiorno = new Map((righeGiorni ?? []).map((r) => [r.data, r]));
+  const confermata = !!settimana;
+
+  const righe = giorni.map((data) => {
+    const salvata = righePerGiorno.get(data);
+    return {
+      data,
+      etichetta: NOMI_GIORNI[giornoSettimanaIso(data)],
+      dataBreve: formattaDataBreve(data),
+      chiuso: isGiornoChiuso(data, chiusure),
+      messaggioChiuso: messaggioChiusura(data, chiusure),
+      stato: (salvata?.stato ?? 'lavorativo') as StatoGiornoOreLavoro,
+      oreOrdinarie: salvata ? salvata.ore_ordinarie : oreOrdinariePreviste(profiloOrario, data),
+      oreStraordinarie: salvata?.ore_straordinarie ?? 0,
+      motivoStraordinario: salvata?.motivo_straordinario ?? '',
+      codiceMalattia: salvata?.codice_malattia ?? '',
+      notaAssenza: salvata?.nota_assenza ?? '',
+    };
+  });
+
+  const totali = totaliSettimanaOreLavoro(righe.filter((r) => !r.chiuso));
 
   return (
     <>
       <NavHeader nome={nomeVisualizzato} ruolo={ruolo} />
-      <main className="mx-auto max-w-2xl px-4 py-10">
-        <a href="/dashboard" className="text-sm text-stone-600 hover:text-stone-900">
-          ← Torna alla dashboard
-        </a>
-        <h1 className="mt-2 text-lg font-medium">Ore di lavoro</h1>
-        <div className="mt-6 rounded-xl border border-dashed border-stone-300 p-6 text-sm text-stone-600">
-          La registrazione delle ore di lavoro effettuate (o delle assenze) sarà disponibile in
-          una fase successiva. Per ora questa sezione conferma solo che sei abilitata a usarla —
-          chiedi all&rsquo;admin se pensavi di esserlo e non la vedi.
+      <main className="mx-auto max-w-3xl space-y-4 px-4 py-8">
+        <div>
+          <a href="/dashboard" className="text-sm text-stone-600 hover:text-stone-900">
+            ← Torna alla dashboard
+          </a>
+          <h1 className="mt-2 text-lg font-medium">Ore di lavoro</h1>
+          <p className="mt-1 text-sm text-stone-600">Settimana {formattaIntervalloItaliano(lunedi, venerdi)}</p>
         </div>
+
+        {confermata && (
+          <p className="rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-900">
+            Settimana confermata il {formattaDataOraItaliana(settimana!.confermata_at).replace('_', ' alle ')}.
+          </p>
+        )}
+
+        {confermata ? (
+          <div className="space-y-2">
+            {righe.map((r) => (
+              <div key={r.data} className="rounded-xl border border-stone-200 bg-white p-3 shadow-sm">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="font-medium">
+                    {r.etichetta} <span className="font-normal text-stone-600">{r.dataBreve}</span>
+                  </span>
+                  {!r.chiuso && (
+                    <span className="text-sm text-stone-600">{ETICHETTE_STATO_ORE_LAVORO[r.stato]}</span>
+                  )}
+                </div>
+                {r.chiuso && <p className="mt-1 text-sm text-stone-600">{r.messaggioChiuso}</p>}
+                {!r.chiuso && r.stato === 'lavorativo' && (
+                  <p className="mt-1 text-sm text-stone-600">
+                    Ordinarie: {r.oreOrdinarie}h · Straordinarie: {r.oreStraordinarie}h
+                    {r.motivoStraordinario ? ` (${r.motivoStraordinario})` : ''}
+                  </p>
+                )}
+                {!r.chiuso && r.stato === 'malattia' && (
+                  <p className="mt-1 text-sm text-stone-600">Codice malattia: {r.codiceMalattia}</p>
+                )}
+                {!r.chiuso && r.stato === 'assenza' && (
+                  <p className="mt-1 text-sm text-stone-600">Nota: {r.notaAssenza}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <FormConEsito action={salvaSettimanaOreLavoro} className="space-y-2">
+            <input type="hidden" name="settimana_inizio" value={lunedi} />
+            {righe.map((r) =>
+              r.chiuso ? (
+                <div
+                  key={r.data}
+                  className="rounded-xl border border-dashed border-stone-300 bg-white p-3 text-sm text-stone-600"
+                >
+                  <span className="font-medium text-stone-800">
+                    {r.etichetta} {r.dataBreve}
+                  </span>{' '}
+                  — {r.messaggioChiuso}
+                </div>
+              ) : (
+                <RigaOreLavoro
+                  key={r.data}
+                  etichettaGiorno={r.etichetta}
+                  dataBreve={r.dataBreve}
+                  valori={{
+                    data: r.data,
+                    stato: r.stato,
+                    oreOrdinarie: r.oreOrdinarie,
+                    oreStraordinarie: r.oreStraordinarie,
+                    motivoStraordinario: r.motivoStraordinario,
+                    codiceMalattia: r.codiceMalattia,
+                    notaAssenza: r.notaAssenza,
+                  }}
+                />
+              )
+            )}
+            <PulsanteInvio className="rounded-lg bg-emerald-700 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-800">
+              Salva modifiche
+            </PulsanteInvio>
+          </FormConEsito>
+        )}
+
+        <p className="rounded-xl border border-stone-200 bg-white p-3 text-sm text-stone-600 shadow-sm">
+          Totale settimana: {totali.ordinarie}h ordinarie + {totali.straordinarie}h straordinarie ={' '}
+          <strong>{totali.totale}h</strong>
+        </p>
+
+        {!confermata && (
+          <ConfermaAzione
+            azione={confermaSettimanaOreLavoro}
+            campiNascosti={{ settimana_inizio: lunedi }}
+            etichetta="Conferma settimana"
+            messaggioConferma="Confermi le ore di questa settimana? Da questo momento non potrai più modificarle autonomamente."
+            tono="neutro"
+          />
+        )}
       </main>
     </>
   );

--- a/components/RigaOreLavoro.tsx
+++ b/components/RigaOreLavoro.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useState } from 'react';
+
+export type StatoGiornoOreLavoro = 'lavorativo' | 'malattia' | 'assenza';
+
+export const ETICHETTE_STATO_ORE_LAVORO: Record<StatoGiornoOreLavoro, string> = {
+  lavorativo: 'Lavorativo',
+  malattia: 'Malattia',
+  assenza: 'Assenza',
+};
+
+export type ValoriGiornoOreLavoro = {
+  data: string;
+  stato: StatoGiornoOreLavoro;
+  oreOrdinarie: number | string;
+  oreStraordinarie: number | string;
+  motivoStraordinario: string;
+  codiceMalattia: string;
+  notaAssenza: string;
+};
+
+const CLASSE_INPUT =
+  'mt-1 rounded-lg border border-stone-300 px-2 py-1 text-sm outline-none focus:border-stone-500';
+const CLASSE_LABEL = 'flex flex-col text-xs text-stone-600';
+
+// Riga editabile di un giorno nel form settimanale di "Ore di lavoro"
+// (specs/18 - report-ore-lavoro.md): mostra solo i campi pertinenti allo
+// stato scelto — ore ordinarie/straordinarie per "Lavorativo", codice
+// per "Malattia", nota per "Assenza" — invece di tutti insieme, coerente
+// con specs/01 - ux.md ("preferire azioni a un tap a form con molti
+// campi da compilare"). Componente client solo per questo toggle
+// visivo: la sottomissione resta un form nativo (ogni campo mantiene il
+// proprio `name`, il genitore è un <form> con Server Action — nessun
+// fetch qui, nessuno stato condiviso tra righe).
+export function RigaOreLavoro({
+  etichettaGiorno,
+  dataBreve,
+  valori,
+}: {
+  etichettaGiorno: string;
+  dataBreve: string;
+  valori: ValoriGiornoOreLavoro;
+}) {
+  const [stato, setStato] = useState<StatoGiornoOreLavoro>(valori.stato);
+  const nomeCampo = (suffisso: string) => `${suffisso}_${valori.data}`;
+
+  return (
+    <div className="rounded-xl border border-stone-200 bg-white p-3 shadow-sm">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="font-medium">
+          {etichettaGiorno} <span className="font-normal text-stone-600">{dataBreve}</span>
+        </span>
+        <select
+          name={nomeCampo('stato')}
+          value={stato}
+          onChange={(e) => setStato(e.target.value as StatoGiornoOreLavoro)}
+          aria-label={`Stato ${etichettaGiorno}`}
+          className="rounded-lg border border-stone-300 px-2 py-1 text-sm outline-none focus:border-stone-500"
+        >
+          {Object.entries(ETICHETTE_STATO_ORE_LAVORO).map(([valore, etichetta]) => (
+            <option key={valore} value={valore}>
+              {etichetta}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {stato === 'lavorativo' && (
+        <div className="mt-2 flex flex-wrap gap-2">
+          <label className={CLASSE_LABEL}>
+            Ore ordinarie
+            <input
+              type="number"
+              min={0}
+              step={0.5}
+              name={nomeCampo('ore_ordinarie')}
+              defaultValue={valori.oreOrdinarie}
+              aria-label={`Ore ordinarie ${etichettaGiorno}`}
+              className={`${CLASSE_INPUT} w-20`}
+            />
+          </label>
+          <label className={CLASSE_LABEL}>
+            Ore straordinarie
+            <input
+              type="number"
+              min={0}
+              step={0.5}
+              name={nomeCampo('ore_straordinarie')}
+              defaultValue={valori.oreStraordinarie}
+              aria-label={`Ore straordinarie ${etichettaGiorno}`}
+              className={`${CLASSE_INPUT} w-20`}
+            />
+          </label>
+          <label className={`${CLASSE_LABEL} min-w-[10rem] flex-1`}>
+            Motivo straordinario
+            <input
+              type="text"
+              name={nomeCampo('motivo_straordinario')}
+              defaultValue={valori.motivoStraordinario}
+              aria-label={`Motivo straordinario ${etichettaGiorno}`}
+              className={CLASSE_INPUT}
+            />
+          </label>
+        </div>
+      )}
+
+      {stato === 'malattia' && (
+        <label className={`${CLASSE_LABEL} mt-2`}>
+          Codice malattia
+          <input
+            type="text"
+            name={nomeCampo('codice_malattia')}
+            defaultValue={valori.codiceMalattia}
+            aria-label={`Codice malattia ${etichettaGiorno}`}
+            className={CLASSE_INPUT}
+          />
+        </label>
+      )}
+
+      {stato === 'assenza' && (
+        <label className={`${CLASSE_LABEL} mt-2`}>
+          Nota giustificativa
+          <input
+            type="text"
+            name={nomeCampo('nota_assenza')}
+            defaultValue={valori.notaAssenza}
+            aria-label={`Nota assenza ${etichettaGiorno}`}
+            className={CLASSE_INPUT}
+          />
+        </label>
+      )}
+    </div>
+  );
+}

--- a/e2e/17-ore-di-lavoro.spec.ts
+++ b/e2e/17-ore-di-lavoro.spec.ts
@@ -36,8 +36,10 @@ test.describe('17 — Ore di lavoro', () => {
 
       try {
         // Abilitazione: la spunta resta visibile riaprendo la pagina, la
-        // card compare in dashboard e apre la sezione dedicata, senza
-        // alcuna form (specs/17: solo l'abilitazione, non la funzione).
+        // card compare in dashboard e apre la sezione dedicata (il
+        // contenuto vero e proprio — tabella settimanale, conferma,
+        // malattia/assenza — è testato in dettaglio in
+        // 18-report-ore-lavoro.spec.ts, non qui).
         await checkbox.check();
         await rigaPropria.getByRole('button', { name: 'Aggiorna' }).click();
         await page.waitForTimeout(1000);
@@ -52,9 +54,6 @@ test.describe('17 — Ore di lavoro', () => {
         await link.click();
         await page.waitForURL('/dashboard/ore-lavoro');
         await expect(page.getByRole('heading', { name: 'Ore di lavoro' })).toBeVisible();
-        await expect(page.getByText(/fase successiva/)).toBeVisible();
-        await expect(page.locator('form')).toHaveCount(0);
-        await expect(page.locator('input')).toHaveCount(0);
 
         await nessunaViolazioneA11yGrave(page);
 

--- a/e2e/18-report-ore-lavoro.spec.ts
+++ b/e2e/18-report-ore-lavoro.spec.ts
@@ -1,0 +1,201 @@
+// Requisito: specs/18 - report-ore-lavoro.md
+//
+// ATTENZIONE: il test principale abilita temporaneamente l'account admin
+// di test al report ore e gli assegna/rimuove un profilo orario di test
+// per poter verificare il contenuto reale della sezione, poi ripristina
+// tutto in `finally` — stesso pattern di 17-ore-di-lavoro.spec.ts e
+// 54-profili-orari.spec.ts. Un solo test esegue l'intero percorso in
+// sequenza (non test separati) per evitare che esecuzioni parallele
+// sullo stesso account condiviso si contendano lo stesso stato
+// (fullyParallel: true, stessa cautela di
+// 16-comunicazione-pasti-rojac.spec.ts).
+//
+// La suite NON preme mai per davvero "Sì" su "Conferma settimana":
+// confermare è irreversibile fino al lunedì successivo (nessuna
+// "riapertura" in questa fase, specs/18) e bloccherebbe la scrittura
+// sull'account di test condiviso per il resto della settimana — stessa
+// cautela già presa per "Pasti comunicati a Rojac" in
+// 16-comunicazione-pasti-rojac.spec.ts. Lo scenario "settimana
+// confermata non è più modificabile" si attiva da solo (altrimenti
+// test.skip) solo se qualcuno l'ha già confermata manualmente questa
+// settimana.
+import { test, expect } from '@playwright/test';
+import { hasCredenziali, nessunaViolazioneA11yGrave, statoAutenticazione } from './helpers';
+
+test.describe('18 — Report ore di lavoro', () => {
+  test.describe('come admin', () => {
+    test.use({ storageState: statoAutenticazione('admin') });
+
+    test.beforeEach(async ({ page }) => {
+      test.skip(!hasCredenziali('admin'), 'richiede E2E_ADMIN_EMAIL/PASSWORD');
+    });
+
+    test('senza abilitazione, /dashboard/ore-lavoro reindirizza alla dashboard', async ({ page }) => {
+      await page.goto('/dashboard/ore-lavoro');
+      await page.waitForURL('/dashboard', { timeout: 20_000 });
+    });
+
+    test('form settimanale: precaricamento dal profilo orario, validazioni, salvataggio, conferma (senza premere Sì)', async ({
+      page,
+    }) => {
+      const nomeProfilo = `E2E ore lavoro ${Date.now()}`;
+
+      // Setup: abilito l'account SENZA profilo orario, per lo scenario
+      // "senza profilo orario assegnato le ore ordinarie partono da zero".
+      await page.goto('/admin/maestre');
+      const rigaAbilita = page.locator('li', { hasText: process.env.E2E_ADMIN_EMAIL! });
+      await rigaAbilita.getByLabel('Ore di lavoro').check();
+      await rigaAbilita.getByRole('button', { name: 'Aggiorna' }).click();
+      await page.waitForTimeout(1000);
+
+      try {
+        await page.goto('/dashboard/ore-lavoro');
+        await expect(page.getByRole('heading', { name: 'Ore di lavoro' })).toBeVisible();
+
+        const giaConfermata = await page.getByText('Settimana confermata il', { exact: false }).count();
+        if (giaConfermata > 0) {
+          // Vedi nota in testa al file: verifico solo la sola lettura,
+          // il resto del test presuppone di poter ancora modificare.
+          await expect(page.getByRole('button', { name: 'Salva modifiche' })).toHaveCount(0);
+          await expect(page.getByRole('button', { name: 'Conferma settimana' })).toHaveCount(0);
+          await nessunaViolazioneA11yGrave(page);
+          return;
+        }
+
+        // Solo i giorni feriali sono mostrati (specs/18, specs/53).
+        await expect(page.getByText('Sabato', { exact: false })).toHaveCount(0);
+        await expect(page.getByText('Domenica', { exact: false })).toHaveCount(0);
+
+        const chiusi = await page.getByText('chiusura scolastica', { exact: false }).count();
+        test.skip(
+          chiusi > 0,
+          'questa settimana contiene un giorno di chiusura scolastica: i valori attesi dal test non sono validi'
+        );
+
+        await expect(page.getByRole('button', { name: 'Salva modifiche' })).toBeVisible();
+        await expect(page.getByRole('button', { name: 'Conferma settimana' })).toBeVisible();
+        await nessunaViolazioneA11yGrave(page);
+
+        // Senza profilo orario: ore ordinarie a 0.
+        await expect(page.getByLabel('Ore ordinarie Lunedì')).toHaveValue('0');
+
+        // Assegno un profilo orario e ricarico: ore ordinarie precaricate.
+        await page.goto('/admin/profili-orari');
+        await page.getByPlaceholder('Nome (es. 35 ore settimanali)').fill(nomeProfilo);
+        await page.getByLabel('Lunedì').fill('7');
+        await page.getByLabel('Martedì').fill('7');
+        await page.getByLabel('Mercoledì').fill('7');
+        await page.getByLabel('Giovedì').fill('7');
+        await page.getByLabel('Venerdì').fill('4');
+        await page.getByRole('button', { name: 'Crea profilo orario' }).click();
+        await expect(page.getByText(nomeProfilo, { exact: false })).toBeVisible({ timeout: 20_000 });
+
+        await page.goto('/admin/maestre');
+        const rigaAssegna = page.locator('li', { hasText: process.env.E2E_ADMIN_EMAIL! });
+        await rigaAssegna.getByLabel('Profilo orario').selectOption({ label: nomeProfilo });
+        await rigaAssegna.getByRole('button', { name: 'Aggiorna' }).click();
+        await page.waitForTimeout(1000);
+
+        await page.goto('/dashboard/ore-lavoro');
+        await expect(page.getByLabel('Ore ordinarie Lunedì')).toHaveValue('7');
+        await expect(page.getByLabel('Ore ordinarie Venerdì')).toHaveValue('4');
+
+        // Straordinario senza motivo: rifiutato, nessuna scrittura.
+        await page.getByLabel('Ore straordinarie Lunedì').fill('2');
+        await page.getByRole('button', { name: 'Salva modifiche' }).click();
+        await expect(page.getByRole('alert')).toContainText('motivo');
+
+        // Con il motivo: accettato, il totale della settimana si aggiorna.
+        await page.getByLabel('Ore straordinarie Lunedì').fill('2');
+        await page.getByLabel('Motivo straordinario Lunedì').fill('Riunione E2E');
+        await page.getByRole('button', { name: 'Salva modifiche' }).click();
+        await expect(page.getByText('2h straordinarie', { exact: false })).toBeVisible({ timeout: 20_000 });
+
+        // Malattia senza codice: rifiutata.
+        await page.getByLabel('Stato Martedì').selectOption('malattia');
+        await page.getByRole('button', { name: 'Salva modifiche' }).click();
+        await expect(page.getByRole('alert')).toContainText('codice malattia');
+
+        // Con il codice: accettata, e resta salvata dopo un ricaricamento.
+        await page.getByLabel('Stato Martedì').selectOption('malattia');
+        await page.getByLabel('Codice malattia Martedì').fill('COD-E2E');
+        await page.getByRole('button', { name: 'Salva modifiche' }).click();
+        await page.waitForTimeout(1000);
+        await page.reload();
+        await expect(page.getByLabel('Stato Martedì')).toHaveValue('malattia');
+        await expect(page.getByLabel('Codice malattia Martedì')).toHaveValue('COD-E2E');
+
+        // Assenza senza nota: rifiutata.
+        await page.getByLabel('Stato Mercoledì').selectOption('assenza');
+        await page.getByRole('button', { name: 'Salva modifiche' }).click();
+        await expect(page.getByRole('alert')).toContainText('nota giustificativa');
+
+        // Con la nota: accettata, e resta salvata dopo un ricaricamento.
+        await page.getByLabel('Stato Mercoledì').selectOption('assenza');
+        await page.getByLabel('Nota assenza Mercoledì').fill('Visita E2E');
+        await page.getByRole('button', { name: 'Salva modifiche' }).click();
+        await page.waitForTimeout(1000);
+        await page.reload();
+        await expect(page.getByLabel('Stato Mercoledì')).toHaveValue('assenza');
+        await expect(page.getByLabel('Nota assenza Mercoledì')).toHaveValue('Visita E2E');
+
+        // "Conferma settimana" chiede conferma esplicita: verifico solo
+        // che il dialogo compaia e che "Annulla" non confermi nulla (non
+        // premo mai "Sì", vedi nota in testa al file).
+        await page.getByRole('button', { name: 'Conferma settimana' }).click();
+        await expect(
+          page.getByText('Da questo momento non potrai più modificarle', { exact: false })
+        ).toBeVisible();
+        await page.getByRole('button', { name: 'Annulla' }).click();
+        await expect(page.getByRole('button', { name: 'Salva modifiche' })).toBeVisible();
+      } finally {
+        // Ripristino: martedì/mercoledì tornano lavorativo, l'account
+        // torna disabilitato e senza profilo, il profilo di test viene
+        // eliminato (svuota anche l'eventuale assegnazione, specs/54).
+        const confermata = await page.getByText('Settimana confermata il', { exact: false }).count();
+        if (!confermata) {
+          await page.goto('/dashboard/ore-lavoro');
+          if ((await page.getByLabel('Stato Martedì').count()) > 0) {
+            await page.getByLabel('Stato Martedì').selectOption('lavorativo');
+          }
+          if ((await page.getByLabel('Stato Mercoledì').count()) > 0) {
+            await page.getByLabel('Stato Mercoledì').selectOption('lavorativo');
+          }
+          const salva = page.getByRole('button', { name: 'Salva modifiche' });
+          if ((await salva.count()) > 0) {
+            await salva.click();
+            await page.waitForTimeout(1000);
+          }
+        }
+
+        await page.goto('/admin/maestre');
+        const rigaRipristina = page.locator('li', { hasText: process.env.E2E_ADMIN_EMAIL! });
+        await rigaRipristina.getByLabel('Ore di lavoro').uncheck();
+        if ((await rigaRipristina.getByLabel('Profilo orario').count()) > 0) {
+          await rigaRipristina.getByLabel('Profilo orario').selectOption({ label: 'Nessun profilo orario' });
+        }
+        await rigaRipristina.getByRole('button', { name: 'Aggiorna' }).click();
+        await page.waitForTimeout(1000);
+
+        await page.goto('/admin/profili-orari');
+        const rigaProfilo = page.getByText(nomeProfilo, { exact: false });
+        if ((await rigaProfilo.count()) > 0) {
+          await rigaProfilo.click();
+          await page.waitForURL(/\/admin\/profili-orari\/.+/);
+          await page.getByRole('button', { name: 'Elimina profilo orario' }).click();
+          await page.getByRole('button', { name: 'Sì' }).click();
+        }
+      }
+    });
+  });
+
+  test.describe('come maestra', () => {
+    test.use({ storageState: statoAutenticazione('maestra') });
+
+    test('senza abilitazione, /dashboard/ore-lavoro reindirizza alla dashboard', async ({ page }) => {
+      test.skip(!hasCredenziali('maestra'), 'richiede E2E_MAESTRA_EMAIL/PASSWORD');
+      await page.goto('/dashboard/ore-lavoro');
+      await page.waitForURL('/dashboard', { timeout: 20_000 });
+    });
+  });
+});

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -7,6 +7,7 @@ export type Profilo = {
   cognome: string;
   ruolo: string;
   abilitato_ore_lavoro: boolean;
+  profilo_orario_id: string | null;
 };
 
 // Richiede una sessione autenticata, senza requisiti di ruolo — usato
@@ -29,7 +30,7 @@ export async function requireProfilo() {
 
   const { data: profilo, error } = await supabase
     .from('profili')
-    .select('nome, cognome, ruolo, abilitato_ore_lavoro')
+    .select('nome, cognome, ruolo, abilitato_ore_lavoro, profilo_orario_id')
     .eq('id', user.id)
     .single();
 

--- a/lib/calendarioScolastico.ts
+++ b/lib/calendarioScolastico.ts
@@ -55,6 +55,25 @@ export async function chiusuraPerData(supabase: SupabaseClient, data: string): P
   return { id: riga.id, dataInizio: riga.data_inizio, dataFine: riga.data_fine, nota: riga.nota };
 }
 
+// Giorni di chiusura registrati dall'admin che si sovrappongono al
+// periodo [inizio, fine] (fa I/O, resta coperta solo da e2e — vedi
+// CLAUDE.md, criterio unit test) — usata dal report ore di lavoro
+// (specs/18 - report-ore-lavoro.md), che deve conoscere le chiusure di
+// un'intera settimana in una sola query invece di una per giorno.
+export async function chiusurePerPeriodo(
+  supabase: SupabaseClient,
+  inizio: string,
+  fine: string
+): Promise<GiornoChiusura[]> {
+  const { data: righe } = await supabase
+    .from('giorni_chiusura')
+    .select('id, data_inizio, data_fine, nota')
+    .lte('data_inizio', fine)
+    .gte('data_fine', inizio);
+
+  return (righe ?? []).map((r) => ({ id: r.id, dataInizio: r.data_inizio, dataFine: r.data_fine, nota: r.nota }));
+}
+
 // Controllo esplicito lato server action, prima di scrivere su
 // presenze/pasti (specs/53 - calendario-scolastico.md): per un messaggio
 // d'errore chiaro, oltre al trigger DB che è la difesa reale (vedi

--- a/lib/date.test.ts
+++ b/lib/date.test.ts
@@ -7,6 +7,8 @@ import {
   formattaIntervalloItaliano,
   formattaMeseItaliano,
   giorniInRange,
+  giorniLavorativiSettimana,
+  giornoSettimanaIso,
   isUltimoGiornoMese,
   isUltimoGiornoSettimana,
   isWeekend,
@@ -223,5 +225,39 @@ describe('isWeekend', () => {
   it("riconosce un venerdì e un lunedì come feriali (confini del weekend)", () => {
     expect(isWeekend('2026-08-28')).toBe(false);
     expect(isWeekend('2026-08-31')).toBe(false);
+  });
+});
+
+describe('giorniLavorativiSettimana', () => {
+  it('restituisce i 5 giorni feriali lunedì-venerdì della settimana, partendo da un giorno feriale', () => {
+    expect(giorniLavorativiSettimana('2026-09-02')).toEqual([
+      '2026-08-31',
+      '2026-09-01',
+      '2026-09-02',
+      '2026-09-03',
+      '2026-09-04',
+    ]);
+  });
+
+  it('partendo da un weekend restituisce comunque i giorni feriali della stessa settimana ISO', () => {
+    expect(giorniLavorativiSettimana('2026-09-06')).toEqual([
+      '2026-08-31',
+      '2026-09-01',
+      '2026-09-02',
+      '2026-09-03',
+      '2026-09-04',
+    ]);
+  });
+});
+
+describe('giornoSettimanaIso', () => {
+  it('restituisce 1 per lunedì e 7 per domenica, in ordine per tutta la settimana', () => {
+    expect(giornoSettimanaIso('2026-08-31')).toBe(1); // lunedì
+    expect(giornoSettimanaIso('2026-09-01')).toBe(2); // martedì
+    expect(giornoSettimanaIso('2026-09-02')).toBe(3); // mercoledì
+    expect(giornoSettimanaIso('2026-09-03')).toBe(4); // giovedì
+    expect(giornoSettimanaIso('2026-09-04')).toBe(5); // venerdì
+    expect(giornoSettimanaIso('2026-09-05')).toBe(6); // sabato
+    expect(giornoSettimanaIso('2026-09-06')).toBe(7); // domenica
   });
 });

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -124,14 +124,22 @@ export function formattaDataOraItaliana(istante: string | Date): string {
   return `${data}_${ora}`;
 }
 
-// Vero se `data` è un sabato o una domenica (specs/53 - calendario-
-// scolastico.md: l'asilo è sempre chiuso in questi giorni, senza bisogno
-// di un giorno di chiusura registrato dall'admin). getUTCDay(): 0 =
-// domenica, 6 = sabato.
-export function isWeekend(data: string): boolean {
+// Giorno della settimana in formato ISO (1 = lunedì ... 7 = domenica),
+// usato da isWeekend e dal report ore di lavoro (specs/18 -
+// report-ore-lavoro.md) per sapere quale campo ore_* del profilo orario
+// (specs/54) corrisponde a una data.
+export function giornoSettimanaIso(data: string): number {
   const [anno, mese, giorno] = data.split('-').map(Number);
   const giornoSettimana = new Date(Date.UTC(anno, mese - 1, giorno, 12)).getUTCDay();
-  return giornoSettimana === 0 || giornoSettimana === 6;
+  return giornoSettimana === 0 ? 7 : giornoSettimana;
+}
+
+// Vero se `data` è un sabato o una domenica (specs/53 - calendario-
+// scolastico.md: l'asilo è sempre chiuso in questi giorni, senza bisogno
+// di un giorno di chiusura registrato dall'admin).
+export function isWeekend(data: string): boolean {
+  const giorno = giornoSettimanaIso(data);
+  return giorno === 6 || giorno === 7;
 }
 
 // Tutte le date da `inizio` a `fine` (incluse), in ordine.
@@ -143,4 +151,14 @@ export function giorniInRange(inizio: string, fine: string): string[] {
     corrente = sommaGiorni(corrente, 1);
   }
   return giorni;
+}
+
+// I 5 giorni feriali (lunedì-venerdì) della settimana che contiene
+// `data` — usati dal report ore di lavoro (specs/18 -
+// report-ore-lavoro.md), che mostra/registra solo questi giorni: sabato
+// e domenica sono chiusura implicita (specs/53), coerente con i profili
+// orari (specs/54) che non prevedono ore in quei due giorni.
+export function giorniLavorativiSettimana(data: string): string[] {
+  const lunedi = lunediSettimana(data);
+  return giorniInRange(lunedi, sommaGiorni(lunedi, 4));
 }

--- a/lib/oreLavoro.test.ts
+++ b/lib/oreLavoro.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+import { oreOrdinariePreviste, totaliSettimanaOreLavoro, validaGiornoOreLavoro, type InputGiornoOreLavoro } from './oreLavoro';
+
+// Tutte funzioni pure (nessun I/O): specs/18 - report-ore-lavoro.md.
+
+describe('oreOrdinariePreviste', () => {
+  const profilo = {
+    ore_lunedi: 7,
+    ore_martedi: 7,
+    ore_mercoledi: 7,
+    ore_giovedi: 7,
+    ore_venerdi: 4,
+  };
+
+  it('restituisce le ore del giorno della settimana corrispondente', () => {
+    expect(oreOrdinariePreviste(profilo, '2026-08-31')).toBe(7); // lunedì
+    expect(oreOrdinariePreviste(profilo, '2026-09-04')).toBe(4); // venerdì
+  });
+
+  it('restituisce 0 senza profilo assegnato', () => {
+    expect(oreOrdinariePreviste(null, '2026-08-31')).toBe(0);
+    expect(oreOrdinariePreviste(undefined, '2026-08-31')).toBe(0);
+  });
+
+  it('funziona anche con valori stringa (numeric via PostgREST)', () => {
+    const profiloStringa = { ...profilo, ore_lunedi: '7.50' };
+    expect(oreOrdinariePreviste(profiloStringa, '2026-08-31')).toBe(7.5);
+  });
+});
+
+function inputBase(sovrascrizioni: Partial<InputGiornoOreLavoro> = {}): InputGiornoOreLavoro {
+  return {
+    data: '2026-08-31',
+    stato: 'lavorativo',
+    oreOrdinarie: 7,
+    oreStraordinarie: 0,
+    motivoStraordinario: '',
+    codiceMalattia: '',
+    notaAssenza: '',
+    ...sovrascrizioni,
+  };
+}
+
+describe('validaGiornoOreLavoro', () => {
+  it('un giorno lavorativo normale è valido', () => {
+    const esito = validaGiornoOreLavoro(inputBase());
+    expect(esito.ok).toBe(true);
+    if (esito.ok) {
+      expect(esito.giorno).toEqual({
+        data: '2026-08-31',
+        stato: 'lavorativo',
+        oreOrdinarie: 7,
+        oreStraordinarie: 0,
+        motivoStraordinario: null,
+        codiceMalattia: null,
+        notaAssenza: null,
+      });
+    }
+  });
+
+  it('ore straordinarie con motivo sono valide', () => {
+    const esito = validaGiornoOreLavoro(
+      inputBase({ oreStraordinarie: 2, motivoStraordinario: 'Riunione genitori' })
+    );
+    expect(esito.ok).toBe(true);
+    if (esito.ok) {
+      expect(esito.giorno.oreStraordinarie).toBe(2);
+      expect(esito.giorno.motivoStraordinario).toBe('Riunione genitori');
+    }
+  });
+
+  it('ore straordinarie senza motivo sono rifiutate', () => {
+    const esito = validaGiornoOreLavoro(inputBase({ oreStraordinarie: 2 }));
+    expect(esito.ok).toBe(false);
+    if (!esito.ok) expect(esito.errore).toContain('motivo');
+  });
+
+  it('un motivo tutto spazi conta come mancante', () => {
+    const esito = validaGiornoOreLavoro(inputBase({ oreStraordinarie: 1, motivoStraordinario: '   ' }));
+    expect(esito.ok).toBe(false);
+  });
+
+  it('malattia con codice è valida e azzera le ore', () => {
+    const esito = validaGiornoOreLavoro(
+      inputBase({ stato: 'malattia', oreOrdinarie: 7, codiceMalattia: 'ABC123' })
+    );
+    expect(esito.ok).toBe(true);
+    if (esito.ok) {
+      expect(esito.giorno.stato).toBe('malattia');
+      expect(esito.giorno.oreOrdinarie).toBe(0);
+      expect(esito.giorno.oreStraordinarie).toBe(0);
+      expect(esito.giorno.codiceMalattia).toBe('ABC123');
+    }
+  });
+
+  it('malattia senza codice è rifiutata', () => {
+    const esito = validaGiornoOreLavoro(inputBase({ stato: 'malattia' }));
+    expect(esito.ok).toBe(false);
+    if (!esito.ok) expect(esito.errore).toContain('codice malattia');
+  });
+
+  it('assenza con nota è valida e azzera le ore', () => {
+    const esito = validaGiornoOreLavoro(
+      inputBase({ stato: 'assenza', oreOrdinarie: 7, notaAssenza: 'Visita medica' })
+    );
+    expect(esito.ok).toBe(true);
+    if (esito.ok) {
+      expect(esito.giorno.stato).toBe('assenza');
+      expect(esito.giorno.oreOrdinarie).toBe(0);
+      expect(esito.giorno.notaAssenza).toBe('Visita medica');
+    }
+  });
+
+  it('assenza senza nota è rifiutata', () => {
+    const esito = validaGiornoOreLavoro(inputBase({ stato: 'assenza' }));
+    expect(esito.ok).toBe(false);
+    if (!esito.ok) expect(esito.errore).toContain('nota giustificativa');
+  });
+
+  it('uno stato sconosciuto viene trattato come lavorativo', () => {
+    const esito = validaGiornoOreLavoro(inputBase({ stato: 'boh' }));
+    expect(esito.ok).toBe(true);
+    if (esito.ok) expect(esito.giorno.stato).toBe('lavorativo');
+  });
+
+  it('ore negative vengono riportate a zero', () => {
+    const esito = validaGiornoOreLavoro(inputBase({ oreOrdinarie: -3, oreStraordinarie: -1 }));
+    expect(esito.ok).toBe(true);
+    if (esito.ok) {
+      expect(esito.giorno.oreOrdinarie).toBe(0);
+      expect(esito.giorno.oreStraordinarie).toBe(0);
+    }
+  });
+});
+
+describe('totaliSettimanaOreLavoro', () => {
+  it('somma ore ordinarie e straordinarie di tutti i giorni', () => {
+    const giorni = [
+      { oreOrdinarie: 7, oreStraordinarie: 0 },
+      { oreOrdinarie: 7, oreStraordinarie: 1.5 },
+      { oreOrdinarie: 7, oreStraordinarie: 0 },
+      { oreOrdinarie: 7, oreStraordinarie: 0 },
+      { oreOrdinarie: 4, oreStraordinarie: 0 },
+    ];
+    expect(totaliSettimanaOreLavoro(giorni)).toEqual({ ordinarie: 32, straordinarie: 1.5, totale: 33.5 });
+  });
+
+  it('un giorno di malattia/assenza (ore a zero) non altera il totale', () => {
+    const giorni = [
+      { oreOrdinarie: 7, oreStraordinarie: 0 },
+      { oreOrdinarie: 0, oreStraordinarie: 0 }, // malattia
+      { oreOrdinarie: 7, oreStraordinarie: 0 },
+    ];
+    expect(totaliSettimanaOreLavoro(giorni)).toEqual({ ordinarie: 14, straordinarie: 0, totale: 14 });
+  });
+
+  it('nessun giorno dà totale zero', () => {
+    expect(totaliSettimanaOreLavoro([])).toEqual({ ordinarie: 0, straordinarie: 0, totale: 0 });
+  });
+});

--- a/lib/oreLavoro.ts
+++ b/lib/oreLavoro.ts
@@ -1,0 +1,134 @@
+import { formattaDataItaliana, giornoSettimanaIso } from '@/lib/date';
+import type { ProfiloOrario } from '@/lib/profiliOrari';
+
+export type StatoGiornoOreLavoro = 'lavorativo' | 'malattia' | 'assenza';
+
+// Ore ordinarie previste per `data` dal profilo orario assegnato
+// all'utente (specs/54 - profili-orari.md), 0 se non ne ha uno
+// (specs/18 - report-ore-lavoro.md, scenario "senza profilo orario
+// assegnato"). Funzione pura, nessun I/O.
+export function oreOrdinariePreviste(profiloOrario: ProfiloOrario | null | undefined, data: string): number {
+  if (!profiloOrario) return 0;
+  switch (giornoSettimanaIso(data)) {
+    case 1:
+      return Number(profiloOrario.ore_lunedi);
+    case 2:
+      return Number(profiloOrario.ore_martedi);
+    case 3:
+      return Number(profiloOrario.ore_mercoledi);
+    case 4:
+      return Number(profiloOrario.ore_giovedi);
+    case 5:
+      return Number(profiloOrario.ore_venerdi);
+    default:
+      return 0;
+  }
+}
+
+export type InputGiornoOreLavoro = {
+  data: string;
+  stato: string;
+  oreOrdinarie: number;
+  oreStraordinarie: number;
+  motivoStraordinario: string;
+  codiceMalattia: string;
+  notaAssenza: string;
+};
+
+export type GiornoOreLavoroValidato = {
+  data: string;
+  stato: StatoGiornoOreLavoro;
+  oreOrdinarie: number;
+  oreStraordinarie: number;
+  motivoStraordinario: string | null;
+  codiceMalattia: string | null;
+  notaAssenza: string | null;
+};
+
+export type EsitoValidazioneGiorno =
+  | { ok: true; giorno: GiornoOreLavoroValidato }
+  | { ok: false; errore: string };
+
+// Valida e normalizza i dati di un giorno del report ore (specs/18 -
+// report-ore-lavoro.md): malattia richiede il codice, assenza richiede
+// una nota, ore straordinarie richiedono un motivo. Passare a
+// malattia/assenza azzera le ore; passare a lavorativo azzera
+// codice/nota. Funzione pura, nessun I/O: chi chiama (la server action)
+// valida così ogni giorno del submit prima di scrivere qualunque cosa
+// (nessun salvataggio parziale su un errore, specs/05 - feedback.md).
+export function validaGiornoOreLavoro(input: InputGiornoOreLavoro): EsitoValidazioneGiorno {
+  const stato: StatoGiornoOreLavoro =
+    input.stato === 'malattia' || input.stato === 'assenza' ? input.stato : 'lavorativo';
+  const etichettaGiorno = formattaDataItaliana(input.data);
+
+  if (stato === 'malattia') {
+    const codiceMalattia = input.codiceMalattia.trim();
+    if (!codiceMalattia) {
+      return { ok: false, errore: `Indica il codice malattia per ${etichettaGiorno}.` };
+    }
+    return {
+      ok: true,
+      giorno: {
+        data: input.data,
+        stato,
+        oreOrdinarie: 0,
+        oreStraordinarie: 0,
+        motivoStraordinario: null,
+        codiceMalattia,
+        notaAssenza: null,
+      },
+    };
+  }
+
+  if (stato === 'assenza') {
+    const notaAssenza = input.notaAssenza.trim();
+    if (!notaAssenza) {
+      return { ok: false, errore: `Indica una nota giustificativa per l'assenza di ${etichettaGiorno}.` };
+    }
+    return {
+      ok: true,
+      giorno: {
+        data: input.data,
+        stato,
+        oreOrdinarie: 0,
+        oreStraordinarie: 0,
+        motivoStraordinario: null,
+        codiceMalattia: null,
+        notaAssenza,
+      },
+    };
+  }
+
+  const oreOrdinarie = Math.max(0, Number(input.oreOrdinarie) || 0);
+  const oreStraordinarie = Math.max(0, Number(input.oreStraordinarie) || 0);
+  const motivoStraordinario = input.motivoStraordinario.trim();
+  if (oreStraordinarie > 0 && !motivoStraordinario) {
+    return { ok: false, errore: `Indica il motivo delle ore straordinarie di ${etichettaGiorno}.` };
+  }
+
+  return {
+    ok: true,
+    giorno: {
+      data: input.data,
+      stato,
+      oreOrdinarie,
+      oreStraordinarie,
+      motivoStraordinario: oreStraordinarie > 0 ? motivoStraordinario : null,
+      codiceMalattia: null,
+      notaAssenza: null,
+    },
+  };
+}
+
+// Totali della settimana (specs/18): somma delle ore ordinarie e
+// straordinarie di tutti i giorni passati (tipicamente i giorni
+// lavorativi/malattia/assenza già registrati — malattia/assenza hanno
+// sempre ore a 0, quindi contribuiscono naturalmente 0 al totale senza
+// bisogno di escluderli esplicitamente). Funzione pura.
+export function totaliSettimanaOreLavoro(
+  giorni: { oreOrdinarie: number | string; oreStraordinarie: number | string }[]
+): { ordinarie: number; straordinarie: number; totale: number } {
+  const ordinarie = giorni.reduce((totale, g) => totale + Number(g.oreOrdinarie), 0);
+  const straordinarie = giorni.reduce((totale, g) => totale + Number(g.oreStraordinarie), 0);
+  return { ordinarie, straordinarie, totale: ordinarie + straordinarie };
+}

--- a/lib/profiliOrari.ts
+++ b/lib/profiliOrari.ts
@@ -1,3 +1,5 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
 // I campi ore_* arrivano da una colonna `numeric` di Postgres via
 // PostgREST: a seconda della versione può essere già un number oppure
 // una stringa (per non perdere precisione) — number | string accetta
@@ -20,4 +22,23 @@ export function totaleOreSettimanali(profilo: ProfiloOrario): number {
   return [profilo.ore_lunedi, profilo.ore_martedi, profilo.ore_mercoledi, profilo.ore_giovedi, profilo.ore_venerdi]
     .map(Number)
     .reduce((totale, ore) => totale + ore, 0);
+}
+
+// Il profilo orario assegnato a un utente (specs/18 -
+// report-ore-lavoro.md, precarica le ore ordinarie del report
+// settimanale), null se `profiloOrarioId` è null o non esiste più (fa
+// I/O, resta coperta solo da e2e — vedi CLAUDE.md, criterio unit test).
+export async function recuperaProfiloOrario(
+  supabase: SupabaseClient,
+  profiloOrarioId: string | null | undefined
+): Promise<ProfiloOrario | null> {
+  if (!profiloOrarioId) return null;
+
+  const { data } = await supabase
+    .from('profili_orari')
+    .select('ore_lunedi, ore_martedi, ore_mercoledi, ore_giovedi, ore_venerdi')
+    .eq('id', profiloOrarioId)
+    .maybeSingle();
+
+  return data;
 }

--- a/lib/versione.ts
+++ b/lib/versione.ts
@@ -4,5 +4,5 @@
 // ora, minuti e secondi (fuso Europe/Rome, non UTC — coerente con
 // lib/date.ts), non solo la data: utile per distinguere più rilasci
 // fatti nello stesso giorno.
-export const VERSIONE_APP = '0.14.0';
-export const DATA_BUILD = '2026-08-31 09:21:39';
+export const VERSIONE_APP = '0.15.0';
+export const DATA_BUILD = '2026-08-31 17:49:08';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "girasole",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "girasole",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "dependencies": {
         "@supabase/ssr": "^0.5.1",
         "@supabase/supabase-js": "^2.45.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "girasole",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/specs/00 - overview.md
+++ b/specs/00 - overview.md
@@ -57,8 +57,10 @@ della maestra, `5x` amministrazione.
   nei report
 - [17 - ore-di-lavoro.md](17%20-%20ore-di-lavoro.md) — abilitazione per
   utente (decisa dall'admin) e punto d'ingresso in dashboard per la
-  futura registrazione delle ore di lavoro/assenze del personale
-  retribuito
+  registrazione delle ore di lavoro/assenze del personale retribuito
+- [18 - report-ore-lavoro.md](18%20-%20report-ore-lavoro.md) — il
+  personale abilitato registra ore ordinarie/straordinarie o
+  malattia/assenza per la settimana corrente, e la conferma
 - [50 - amministrazione_base.md](50%20-%20amministrazione_base.md) — creazione
   sezioni/bambini e assegnazione maestre/assistenti alle sezioni (admin)
 - [51 - report.md](51%20-%20report.md) — report tabellari di

--- a/specs/17 - ore-di-lavoro.md
+++ b/specs/17 - ore-di-lavoro.md
@@ -4,12 +4,12 @@
 Personale retribuito (maestra, assistente o admin) abilitato dall'admin.
 
 ## Obiettivo
-Introdurre, in modo progressivo, la possibilità per il personale
-retribuito di registrare le ore di lavoro effettuate o le assenze. In
-questa prima fase si abilita solo l'accesso alla sezione, utente per
-utente, deciso dall'admin: **come** le ore vengono effettivamente
-segnate (form, calcolo del totale, riepiloghi, export) è fuori scope,
-sarà definito in una fase successiva.
+Dare al personale retribuito la possibilità di registrare le ore di
+lavoro effettuate o le assenze, abilitando l'accesso alla sezione utente
+per utente, deciso dall'admin. Questo requisito copre solo CHI vede la
+sezione "Ore di lavoro" e la sua abilitazione; il contenuto della
+sezione (form settimanale, conferma, malattia/assenza) è descritto in
+[18 - report-ore-lavoro.md](18%20-%20report-ore-lavoro.md).
 
 ## Scenario: l'admin abilita un utente al report ore in fase di creazione
 Dato che sono autenticato come admin
@@ -40,13 +40,6 @@ Allora non vedo il pulsante/scheda "Ore di lavoro"
 E se provo ad aprire direttamente `/dashboard/ore-lavoro`, vengo
 reindirizzata alla dashboard invece di vedere il contenuto della sezione
 
-## Scenario: contenuto della sezione in questa fase
-Dato che sono abilitata al report ore e apro `/dashboard/ore-lavoro`
-Allora vedo un messaggio che spiega che la registrazione vera e propria
-(ore lavorate o assenze) sarà disponibile in una fase successiva
-E non vedo alcuna form per inserire dati: questa fase abilita solo
-l'accesso alla sezione, non la sua funzione
-
 ## Regole
 - Nuovo campo `profili.abilitato_ore_lavoro` (booleano, default falso):
   decide da solo la visibilità della sezione e l'accesso alla pagina,
@@ -64,10 +57,10 @@ l'accesso alla sezione, non la sua funzione
   oggi per Presenze/Pasti), ma la disposizione è sempre quella — quando
   il numero di card visibili è dispari, l'ultima occupa l'intera
   larghezza invece di lasciare un buco vuoto in griglia.
-- Fuori scope in questa fase: come le ore vengono effettivamente
-  registrate (form di inserimento, calcolo ore/assenze, riepiloghi,
-  export, eventuali approvazioni) — qui si abilita solo l'accesso al
-  punto d'ingresso della sezione.
+- Come le ore vengono effettivamente registrate (form di inserimento,
+  conferma settimanale, malattia/assenza) è descritto in
+  [18 - report-ore-lavoro.md](18%20-%20report-ore-lavoro.md): questo
+  requisito resta quello che decide solo CHI vede la sezione.
 - L'admin può anche definire un "orario tipo" settimanale (ore previste
   per giorno) e assegnarlo a ciascuna persona, indipendentemente
   dall'abilitazione descritta qui — vedi

--- a/specs/18 - report-ore-lavoro.md
+++ b/specs/18 - report-ore-lavoro.md
@@ -1,0 +1,148 @@
+# 18 — Report ore di lavoro
+
+## Attori
+Personale retribuito (maestra, assistente o admin) abilitato al report
+ore (vedi [17 - ore-di-lavoro.md](17%20-%20ore-di-lavoro.md)).
+
+## Obiettivo
+Dare al personale abilitato un modo per registrare, settimana per
+settimana, le ore di lavoro effettuate — ordinarie e straordinarie — o
+un giorno di malattia/assenza, e per confermare la settimana una volta
+verificata, così da renderla stabile (non più modificabile in autonomia).
+Questo requisito estende
+[17 - ore-di-lavoro.md](17%20-%20ore-di-lavoro.md), che finora abilitava
+solo l'accesso a una sezione placeholder: da qui in poi
+`/dashboard/ore-lavoro` mostra il contenuto vero e proprio.
+
+## Scenario: aprire la sezione mostra la settimana corrente con le ore precaricate
+Dato che sono autenticata come personale abilitato al report ore, con un
+profilo orario assegnato (vedi
+[54 - profili-orari.md](54%20-%20profili-orari.md))
+Quando apro "Ore di lavoro"
+Allora vedo una tabella con una riga per ciascun giorno feriale
+(lunedì-venerdì) della settimana corrente
+E per ogni giorno il campo "Ore ordinarie" è precompilato con le ore
+previste dal mio profilo orario per quel giorno della settimana
+E vedo anche un campo "Ore straordinarie", a 0 di default
+
+## Scenario: senza profilo orario assegnato le ore ordinarie partono da zero
+Dato che sono abilitata al report ore ma non ho un profilo orario
+assegnato
+Quando apro "Ore di lavoro"
+Allora il campo "Ore ordinarie" di ogni giorno parte da 0, comunque
+modificabile a mano
+
+## Scenario: salvare le ore della settimana
+Quando modifico le ore di uno o più giorni e premo "Salva modifiche"
+Allora i valori inseriti sono salvati e restano tali riaprendo la pagina
+E vedo il totale delle ore della settimana (ordinarie + straordinarie)
+aggiornato di conseguenza
+
+## Scenario: le ore straordinarie richiedono un motivo
+Quando per un giorno inserisco delle ore straordinarie senza indicarne
+il motivo, e premo "Salva modifiche"
+Allora vedo un messaggio d'errore che richiede il motivo
+E nessuna modifica di quel salvataggio viene registrata
+
+## Scenario: segnare un giorno di malattia
+Quando per un giorno scelgo lo stato "Malattia" e indico il codice
+malattia ricevuto dal medico, e premo "Salva modifiche"
+Allora quel giorno risulta segnato come malattia con il codice indicato,
+senza ore ordinarie né straordinarie
+
+## Scenario: la malattia richiede il codice
+Quando per un giorno scelgo lo stato "Malattia" senza indicare il
+codice, e premo "Salva modifiche"
+Allora vedo un messaggio d'errore che richiede il codice malattia
+E nessuna modifica di quel salvataggio viene registrata
+
+## Scenario: segnare un giorno di assenza
+Quando per un giorno scelgo lo stato "Assenza" e indico una nota
+giustificativa, e premo "Salva modifiche"
+Allora quel giorno risulta segnato come assenza con la nota indicata,
+senza ore ordinarie né straordinarie
+
+## Scenario: l'assenza richiede una nota giustificativa
+Quando per un giorno scelgo lo stato "Assenza" senza indicare una nota,
+e premo "Salva modifiche"
+Allora vedo un messaggio d'errore che richiede la nota
+E nessuna modifica di quel salvataggio viene registrata
+
+## Scenario: confermare la settimana
+Quando, dopo aver verificato le ore, premo "Conferma settimana" e
+confermo l'azione
+Allora la settimana risulta confermata, con la data/ora della conferma
+mostrate a schermo
+E ogni giorno non ancora salvato esplicitamente viene comunque
+registrato, con le ore precaricate dal profilo orario (o 0 se nessun
+profilo è assegnato)
+
+## Scenario: una settimana confermata non è più modificabile dal personale
+Dato che la settimana corrente è già stata confermata
+Quando apro "Ore di lavoro"
+Allora vedo i dati della settimana in sola lettura (nessun campo
+modificabile, nessun pulsante "Salva modifiche" o "Conferma settimana")
+
+## Scenario: un giorno di chiusura scolastica non è modificabile
+Dato che un giorno della settimana corrente è un giorno di chiusura
+scolastica (weekend, o un intervallo registrato dall'admin — vedi
+[53 - calendario-scolastico.md](53%20-%20calendario-scolastico.md))
+Quando apro "Ore di lavoro"
+Allora quel giorno mostra l'informazione di chiusura, senza alcun campo
+da compilare
+
+## Scenario: accesso negato senza abilitazione
+Dato che il mio profilo non è abilitato al report ore
+Quando provo ad aprire `/dashboard/ore-lavoro`
+Allora vengo reindirizzata alla dashboard (vedi
+[17 - ore-di-lavoro.md](17%20-%20ore-di-lavoro.md))
+
+## Regole
+- Solo i giorni feriali (lunedì-venerdì) della settimana corrente sono
+  mostrati: sabato e domenica sono chiusura implicita
+  (specs/53), coerente con i profili orari (specs/54) che non prevedono
+  ore in quei due giorni.
+- Un giorno è in uno di tre stati, esclusivi: **lavorativo** (ore
+  ordinarie/straordinarie), **malattia** (richiede il codice ricevuto
+  dal medico) o **assenza** (richiede una nota giustificativa). Passare
+  a malattia o assenza azzera le ore ordinarie/straordinarie di quel
+  giorno; passare a lavorativo azzera codice malattia/nota assenza.
+- Le ore ordinarie di un giorno sono precaricate dal profilo orario
+  assegnato all'utente (campo del giorno della settimana corrispondente,
+  specs/54), ma restano modificabili prima della conferma: il personale
+  "verifica" il precaricato, non lo subisce.
+- Le ore straordinarie concorrono al calcolo del monte ore del
+  personale: qui si registra solo il dato (ore + motivo), il calcolo e
+  la presentazione di un monte ore aggregato sono fuori scope (vedi
+  sotto).
+- La settimana è "confermata" quando esiste una riga corrispondente
+  nella tabella `ore_lavoro_settimane` (stesso pattern di
+  `report_giornalieri_inviati`/`report_periodici_inviati`, specs/52:
+  l'esistenza della riga è la conferma, non un flag booleano separato
+  da tenere sincronizzato). Una volta confermata, il personale non può
+  più modificare i giorni di quella settimana (RLS in
+  `supabase/migrations/0025_report_ore_lavoro.sql`); l'admin sì, sempre
+  — anche se non c'è ancora un'interfaccia per farlo (vedi Fuori scope).
+- Il blocco di un giorno di chiusura scolastica vale per QUALUNQUE ruolo,
+  admin incluso — stesso principio già in vigore per presenze e pasti
+  (specs/53): un asilo chiuso non ha ore di lavoro da registrare per
+  nessuno, non è un permesso di scrittura ma un vincolo di coerenza dei
+  dati. Imposto anche con un trigger sul database, non solo in UI.
+- Nessuna scrittura silenziosa: un salvataggio che fallisce la
+  validazione (motivo/codice/nota mancante) non salva nessuno dei giorni
+  di quel submit, nemmeno quelli validi — il personale corregge il
+  giorno segnalato e reinvia (stesso pattern "errore ⇒ dati preservati"
+  di specs/05 - feedback.md, i campi già compilati restano tali).
+
+## Fuori scope in questa fase
+- Un'interfaccia dedicata per l'admin per rivedere/correggere le
+  settimane (confermate o no) di un altro utente: i permessi RLS sono
+  già pronti (l'admin può leggere/scrivere qualunque riga), ma non c'è
+  ancora una pagina che lo consenta. Nel frattempo l'admin può
+  intervenire dal SQL Editor di Supabase se necessario.
+- Il calcolo effettivo di un monte ore/straordinari a partire dai dati
+  registrati, ed eventuali riepiloghi o export.
+- Navigazione tra settimane passate o future: si vede sempre e solo la
+  settimana corrente.
+- "Riaprire" una settimana già confermata (renderla di nuovo
+  modificabile dal personale): nessuna azione la offre in questa fase.

--- a/supabase/migrations/0025_report_ore_lavoro.sql
+++ b/supabase/migrations/0025_report_ore_lavoro.sql
@@ -1,0 +1,136 @@
+-- Girasole — Report ore di lavoro (specs/18 - report-ore-lavoro.md): il
+-- personale abilitato (specs/17) registra ore ordinarie/straordinarie o
+-- malattia/assenza per ciascun giorno feriale della settimana corrente,
+-- e conferma la settimana quando l'ha verificata. Una settimana
+-- confermata non è più modificabile in autonomia dal personale, solo
+-- dall'admin.
+--
+-- Incolla questo file nel SQL Editor di Supabase (dopo
+-- 0024_profili_orari.sql) ed eseguilo una volta sola.
+
+-- =========================================================
+-- Un giorno registrato per un utente: lavorativo (ore ordinarie/
+-- straordinarie), malattia (codice obbligatorio) o assenza (nota
+-- obbligatoria) — mutuamente esclusivi, imposti anche a livello di
+-- database (non solo in UI) perché sono dati che, una volta confermati,
+-- diventano stabili.
+-- =========================================================
+create table public.ore_lavoro_giorni (
+  id uuid primary key default gen_random_uuid(),
+  utente_id uuid not null references public.profili(id) on delete cascade,
+  data date not null,
+  stato text not null default 'lavorativo' check (stato in ('lavorativo', 'malattia', 'assenza')),
+  ore_ordinarie numeric(4, 2) not null default 0 check (ore_ordinarie >= 0),
+  ore_straordinarie numeric(4, 2) not null default 0 check (ore_straordinarie >= 0),
+  motivo_straordinario text,
+  codice_malattia text,
+  nota_assenza text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (utente_id, data),
+  constraint ore_lavoro_giorni_straordinario_con_motivo
+    check (ore_straordinarie = 0 or (motivo_straordinario is not null and length(trim(motivo_straordinario)) > 0)),
+  constraint ore_lavoro_giorni_malattia_con_codice
+    check (stato <> 'malattia' or (codice_malattia is not null and length(trim(codice_malattia)) > 0)),
+  constraint ore_lavoro_giorni_assenza_con_nota
+    check (stato <> 'assenza' or (nota_assenza is not null and length(trim(nota_assenza)) > 0))
+);
+
+create index ore_lavoro_giorni_utente_data_idx on public.ore_lavoro_giorni (utente_id, data);
+
+-- =========================================================
+-- Conferma di una settimana: l'esistenza della riga È la conferma,
+-- stesso pattern già usato per report_giornalieri_inviati/
+-- report_periodici_inviati (0009/specs/52) invece di un flag booleano
+-- da tenere sincronizzato. settimana_inizio è sempre un lunedì.
+-- =========================================================
+create table public.ore_lavoro_settimane (
+  id uuid primary key default gen_random_uuid(),
+  utente_id uuid not null references public.profili(id) on delete cascade,
+  settimana_inizio date not null,
+  confermata_at timestamptz not null default now(),
+  unique (utente_id, settimana_inizio)
+);
+
+alter table public.ore_lavoro_giorni enable row level security;
+alter table public.ore_lavoro_settimane enable row level security;
+
+-- Vero se la settimana che contiene p_giorno è già stata confermata da
+-- p_utente. p_giorno - (isodow - 1) = lunedì di quella settimana (in
+-- Postgres date - integer = date, isodow: 1 = lunedì ... 7 = domenica).
+create or replace function public.settimana_ore_lavoro_confermata(p_utente uuid, p_giorno date)
+returns boolean
+language sql stable
+as $$
+  select exists (
+    select 1 from public.ore_lavoro_settimane
+    where utente_id = p_utente
+      and settimana_inizio = p_giorno - (extract(isodow from p_giorno)::int - 1)
+  );
+$$;
+
+-- select: i propri dati, o l'admin (che in una fase successiva potrà
+-- rivedere/correggere i dati di chiunque — specs/18, "Fuori scope": i
+-- permessi sono già pronti, l'interfaccia non ancora).
+create policy "ore_lavoro_giorni_select_own_or_admin" on public.ore_lavoro_giorni
+  for select using (utente_id = auth.uid() or public.ruolo_corrente() = 'admin');
+
+-- insert/update: il proprietario, solo se la settimana di quel giorno
+-- non è già confermata; l'admin sempre (specs/18: "non è più
+-- modificabile in autonomia dal personale, ma solo da admin").
+create policy "ore_lavoro_giorni_insert_own_o_admin" on public.ore_lavoro_giorni
+  for insert with check (
+    public.ruolo_corrente() = 'admin'
+    or (utente_id = auth.uid() and not public.settimana_ore_lavoro_confermata(utente_id, data))
+  );
+
+create policy "ore_lavoro_giorni_update_own_o_admin" on public.ore_lavoro_giorni
+  for update using (
+    public.ruolo_corrente() = 'admin'
+    or (utente_id = auth.uid() and not public.settimana_ore_lavoro_confermata(utente_id, data))
+  );
+
+grant select, insert, update on public.ore_lavoro_giorni to authenticated;
+
+-- Stesso vincolo di "giorno chiuso" già in vigore per presenze/pasti
+-- (specs/53 - calendario-scolastico.md, la cui nota "Regole" rimandava
+-- esplicitamente a questa futura funzionalità): vale per QUALUNQUE
+-- ruolo, admin incluso, riusando la funzione public.giorno_chiuso già
+-- definita in 0022_calendario_scolastico.sql.
+create or replace function public.impedisci_ore_lavoro_giorno_chiuso()
+returns trigger
+language plpgsql
+as $$
+begin
+  if public.giorno_chiuso(new.data) then
+    raise exception 'Impossibile registrare le ore: % è un giorno di chiusura scolastica.', new.data;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists ore_lavoro_giorni_blocca_se_chiuso on public.ore_lavoro_giorni;
+create trigger ore_lavoro_giorni_blocca_se_chiuso
+  before insert or update on public.ore_lavoro_giorni
+  for each row execute procedure public.impedisci_ore_lavoro_giorno_chiuso();
+
+-- select/insert su ore_lavoro_settimane: i propri dati, o l'admin.
+-- Nessun update (una conferma non si modifica, si registra soltanto);
+-- delete solo admin, predisposto per un'eventuale "riapertura" futura
+-- della settimana (fuori scope in questa fase: nessuna UI la usa).
+create policy "ore_lavoro_settimane_select_own_or_admin" on public.ore_lavoro_settimane
+  for select using (utente_id = auth.uid() or public.ruolo_corrente() = 'admin');
+
+create policy "ore_lavoro_settimane_insert_own_or_admin" on public.ore_lavoro_settimane
+  for insert with check (utente_id = auth.uid() or public.ruolo_corrente() = 'admin');
+
+create policy "ore_lavoro_settimane_delete_admin" on public.ore_lavoro_settimane
+  for delete using (public.ruolo_corrente() = 'admin');
+
+grant select, insert, delete on public.ore_lavoro_settimane to authenticated;
+
+-- Grant preventivo per service_role: nessuna route lo usa ancora per
+-- queste due tabelle, ma è lo stesso bug già capitato più volte per
+-- altre tabelle nuove (vedi 0018_grant_service_role_report.sql e
+-- successivi) — lo evitiamo da subito.
+grant select on public.ore_lavoro_giorni, public.ore_lavoro_settimane to service_role;


### PR DESCRIPTION
## Summary
- `/dashboard/ore-lavoro` (finora un placeholder, v0.13.0) mostra ora la settimana corrente in forma tabellare — una card per ciascun giorno feriale (lunedì-venerdì): ore ordinarie precaricate dal profilo orario assegnato (v0.14.0) e comunque modificabili, ore straordinarie libere (con motivo obbligatorio), stato "Malattia" (codice ricevuto dal medico obbligatorio) o "Assenza" (nota giustificativa obbligatoria) in alternativa alle ore.
- Il personale salva le modifiche ("Salva modifiche", ripetibile) e conferma la settimana quando l'ha verificata ("Conferma settimana", irreversibile per il personale): da quel momento la settimana è in sola lettura per lui, modificabile solo dall'admin (RLS già pronta; l'interfaccia dedicata per l'admin resta fuori scope, come dichiarato in `specs/18`).
- Un giorno di chiusura scolastica (weekend o intervallo registrato dall'admin) non è modificabile da nessuno — riusa lo stesso trigger `public.giorno_chiuso` già in vigore per presenze/pasti (specs/53, che rimandava esplicitamente a questa futura funzionalità).
- Nuove tabelle `ore_lavoro_giorni` e `ore_lavoro_settimane` (`supabase/migrations/0025_report_ore_lavoro.sql`) — l'esistenza della riga in `ore_lavoro_settimane` è la conferma, stesso pattern di `report_giornalieri_inviati` (specs/52).
- Nuovo `specs/18 - report-ore-lavoro.md` (in indice su `specs/00`); `specs/17` aggiornata a rimandarci per il "come" (non più un placeholder).
- `lib/oreLavoro.ts` (puro): precaricamento dal profilo orario, validazione delle tre regole di obbligatorietà (motivo/codice/nota), totali settimanali. `lib/date.ts`: nuove `giornoSettimanaIso`/`giorniLavorativiSettimana`. `components/RigaOreLavoro.tsx` mostra solo i campi pertinenti allo stato scelto (specs/01 - ux.md, "preferire azioni a un tap a form con molti campi").

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx next lint`
- [x] `npx vitest run` (169 test, inclusi i 23 nuovi unit test di `lib/oreLavoro.test.ts` e le estensioni di `lib/date.test.ts`)
- [x] `npx jscpd` (nessun nuovo duplicato — i 3 clone segnalati sono preesistenti)
- [ ] `npx playwright test e2e/18-report-ore-lavoro.spec.ts` dal tuo ambiente locale (non eseguibile in questo ambiente sandbox — nessun dev server/credenziali Supabase). **Nota importante**: quel file non preme mai per davvero "Sì" su "Conferma settimana" — confermare è irreversibile fino al lunedì successivo (nessuna "riapertura" in questa fase) e bloccherebbe la scrittura sull'account di test condiviso per il resto della settimana, stessa cautela già presa per "Pasti comunicati a Rojac" (specs/16). Lo scenario "settimana confermata" si verifica solo se qualcuno l'ha già confermata manualmente questa settimana (altrimenti `test.skip`).
- [ ] Rieseguire anche `e2e/17-ore-di-lavoro.spec.ts` (assert aggiornati per il nuovo contenuto reale della pagina) dal tuo ambiente locale.

## Da fare dopo il merge
- Applicare `supabase/migrations/0025_report_ore_lavoro.sql` nel SQL Editor di Supabase (progetto di test e produzione) — senza, `/dashboard/ore-lavoro` fallisce a leggere/scrivere le nuove tabelle.

---
_Generated by [Claude Code](https://claude.ai/code/session_0165puuH5x8UEN9SYds2KVhF)_