### PR TITLE
Ore di lavoro: registrabili anche nei giorni di chiusura scolastica (v0.15.1)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1250,6 +1250,49 @@ Due bug segnalati dopo l'uso reale di `/admin/maestre`.
       `/dashboard/ore-lavoro` — senza, la pagina fallisce a leggere/
       scrivere le tabelle `ore_lavoro_giorni`/`ore_lavoro_settimane`.
 
+## Ore di lavoro: registrabili anche nei giorni di chiusura scolastica (v0.15.1)
+- [x] Richiesta esplicita dell'utente, correzione rispetto a v0.15.0: il
+      personale può lavorare (pulizie, attività amministrative,
+      formazione...) anche nei giorni in cui l'asilo è chiuso (weekend
+      o chiusura registrata dall'admin) — il blocco introdotto in
+      0025_report_ore_lavoro.sql (che riprendeva la nota "in futuro" di
+      specs/53/0022) era quindi sbagliato per questo registro.
+- [x] `specs/18 - report-ore-lavoro.md`: la tabella mostra ora tutti i 7
+      giorni della settimana (non solo lunedì-venerdì), tutti
+      pienamente modificabili; un giorno di chiusura mostra solo
+      un'informazione, senza bloccare nulla. `specs/53 -
+      calendario-scolastico.md` corretta di conseguenza (l'eccezione
+      per le ore di lavoro è ora dichiarata esplicitamente, non più "in
+      futuro varrà anche lì").
+- [x] `supabase/migrations/0026_ore_lavoro_permesse_giorni_chiusi.sql`
+      (nuova, non modifica 0025 già applicata): rimuove il trigger
+      `ore_lavoro_giorni_blocca_se_chiuso` e la funzione
+      `impedisci_ore_lavoro_giorno_chiuso`. Le RLS restano invariate
+      (non facevano riferimento alla chiusura).
+- [x] `lib/date.ts:giorniLavorativiSettimana` (5 giorni) sostituita da
+      `giorniSettimana` (7 giorni, lunedì-domenica) — unico punto d'uso.
+      `lib/oreLavoro.ts`: nuova `notaGiornoChiusoOreLavoro` (pura, con
+      unit test), testo dedicato che non riusa
+      `calendarioScolastico.ts:messaggioChiusura` (che parla di un
+      blocco reale, fuorviante qui) — dice esplicitamente "puoi comunque
+      registrare le ore". `components/RigaOreLavoro.tsx` mostra questa
+      nota come avviso informativo, non più una card "chiusa" senza
+      campi. `app/dashboard/ore-lavoro/actions.ts` non salta più i
+      giorni chiusi nel salvataggio/completamento pre-conferma.
+- [x] Verificato: `npx tsc --noEmit`, `npx next lint`, `npx vitest run`
+      (173 test) e `npx jscpd` (3 clone preesistenti, sotto soglia,
+      nessuno nuovo) puliti. `e2e/18-report-ore-lavoro.spec.ts`
+      aggiornato (sabato/domenica ora editabili e verificati, niente
+      più skip legato a un giorno chiuso) — non eseguibile in questo
+      ambiente sandbox, da verificare con
+      `npx playwright test e2e/18-report-ore-lavoro.spec.ts` dal tuo
+      ambiente locale (stessa cautela di v0.15.0: non preme mai "Sì" su
+      "Conferma settimana").
+- [ ] **Da fare da parte tua**: applica
+      `supabase/migrations/0026_ore_lavoro_permesse_giorni_chiusi.sql`
+      nel SQL Editor di Supabase (test e produzione) — senza, il
+      trigger continua a bloccare le ore nei giorni di chiusura.
+
 ## Backlog — Fase 2/3
 - [ ] Rette mensili e stato pagamento
 - [ ] Portale genitori (UI dedicata)

--- a/app/dashboard/ore-lavoro/actions.ts
+++ b/app/dashboard/ore-lavoro/actions.ts
@@ -2,9 +2,8 @@
 
 import { revalidatePath } from 'next/cache';
 import { requireStaff, assicuraAccessoOreLavoro } from '@/lib/auth';
-import { oggi, giorniLavorativiSettimana } from '@/lib/date';
+import { oggi, giorniSettimana } from '@/lib/date';
 import { validaGiornoOreLavoro, oreOrdinariePreviste } from '@/lib/oreLavoro';
-import { isGiornoChiuso, chiusurePerPeriodo } from '@/lib/calendarioScolastico';
 import { recuperaProfiloOrario } from '@/lib/profiliOrari';
 import type { EsitoAzione } from '@/components/FormConEsito';
 
@@ -14,7 +13,7 @@ import type { EsitoAzione } from '@/components/FormConEsito';
 // arrivasse dal campo nascosto settimana_inizio.
 function settimanaCorrenteOSbagliata(formData: FormData): string | null {
   const settimanaInizio = (formData.get('settimana_inizio') as string) || '';
-  const giorni = giorniLavorativiSettimana(oggi());
+  const giorni = giorniSettimana(oggi());
   return settimanaInizio === giorni[0] ? settimanaInizio : null;
 }
 
@@ -31,14 +30,10 @@ export async function salvaSettimanaOreLavoro(_stato: EsitoAzione, formData: For
     return { ok: false, messaggio: 'Puoi modificare solo la settimana corrente.' };
   }
 
-  const giorni = giorniLavorativiSettimana(settimanaInizio);
-  const venerdi = giorni[giorni.length - 1];
-  const chiusure = await chiusurePerPeriodo(supabase, settimanaInizio, venerdi);
+  const giorni = giorniSettimana(settimanaInizio);
 
   const daScrivere = [];
   for (const data of giorni) {
-    if (isGiornoChiuso(data, chiusure)) continue;
-
     const esito = validaGiornoOreLavoro({
       data,
       stato: (formData.get(`stato_${data}`) as string) || 'lavorativo',
@@ -95,9 +90,7 @@ export async function confermaSettimanaOreLavoro(_stato: EsitoAzione, formData: 
     return { ok: false, messaggio: 'Puoi confermare solo la settimana corrente.' };
   }
 
-  const giorni = giorniLavorativiSettimana(settimanaInizio);
-  const venerdi = giorni[giorni.length - 1];
-  const chiusure = await chiusurePerPeriodo(supabase, settimanaInizio, venerdi);
+  const giorni = giorniSettimana(settimanaInizio);
 
   const { data: esistenti } = await supabase
     .from('ore_lavoro_giorni')
@@ -109,7 +102,7 @@ export async function confermaSettimanaOreLavoro(_stato: EsitoAzione, formData: 
   const profiloOrario = await recuperaProfiloOrario(supabase, profilo?.profilo_orario_id);
 
   const daCompletare = giorni
-    .filter((data) => !isGiornoChiuso(data, chiusure) && !dateEsistenti.has(data))
+    .filter((data) => !dateEsistenti.has(data))
     .map((data) => ({
       utente_id: user.id,
       data,

--- a/app/dashboard/ore-lavoro/page.tsx
+++ b/app/dashboard/ore-lavoro/page.tsx
@@ -4,10 +4,10 @@ import { PulsanteInvio } from '@/components/PulsanteInvio';
 import { ConfermaAzione } from '@/components/ConfermaAzione';
 import { RigaOreLavoro, ETICHETTE_STATO_ORE_LAVORO, type StatoGiornoOreLavoro } from '@/components/RigaOreLavoro';
 import { requireStaff, assicuraAccessoOreLavoro } from '@/lib/auth';
-import { oggi, giorniLavorativiSettimana, giornoSettimanaIso, formattaIntervalloItaliano, formattaDataBreve, formattaDataOraItaliana } from '@/lib/date';
-import { oreOrdinariePreviste, totaliSettimanaOreLavoro } from '@/lib/oreLavoro';
+import { oggi, giorniSettimana, giornoSettimanaIso, formattaIntervalloItaliano, formattaDataBreve, formattaDataOraItaliana } from '@/lib/date';
+import { oreOrdinariePreviste, totaliSettimanaOreLavoro, notaGiornoChiusoOreLavoro } from '@/lib/oreLavoro';
 import { recuperaProfiloOrario } from '@/lib/profiliOrari';
-import { isGiornoChiuso, messaggioChiusura, chiusurePerPeriodo } from '@/lib/calendarioScolastico';
+import { isGiornoChiuso, chiusurePerPeriodo } from '@/lib/calendarioScolastico';
 import { salvaSettimanaOreLavoro, confermaSettimanaOreLavoro } from './actions';
 
 export const dynamic = 'force-dynamic';
@@ -18,19 +18,22 @@ const NOMI_GIORNI: Record<number, string> = {
   3: 'Mercoledì',
   4: 'Giovedì',
   5: 'Venerdì',
+  6: 'Sabato',
+  7: 'Domenica',
 };
 
 // Sezione "Ore di lavoro" (specs/18 - report-ore-lavoro.md): il
 // personale abilitato (specs/17) registra ore/malattia/assenza per la
-// settimana corrente e la conferma. Una volta confermata, la pagina
-// mostra i dati in sola lettura (nessun campo modificabile).
+// settimana corrente (tutti i 7 giorni: il personale può lavorare anche
+// nei giorni in cui l'asilo è chiuso, specs/53) e la conferma. Una volta
+// confermata, la pagina mostra i dati in sola lettura.
 export default async function OreLavoroPage() {
   const { supabase, user, profilo, ruolo } = await requireStaff({});
   assicuraAccessoOreLavoro(profilo?.abilitato_ore_lavoro);
 
   const nomeVisualizzato = profilo?.nome || user.email || '';
-  const giorni = giorniLavorativiSettimana(oggi());
-  const [lunedi, , , , venerdi] = giorni;
+  const giorni = giorniSettimana(oggi());
+  const [lunedi, , , , , , domenica] = giorni;
 
   const [profiloOrario, { data: righeGiorni }, { data: settimana }, chiusure] = await Promise.all([
     recuperaProfiloOrario(supabase, profilo?.profilo_orario_id),
@@ -45,7 +48,7 @@ export default async function OreLavoroPage() {
       .eq('utente_id', user.id)
       .eq('settimana_inizio', lunedi)
       .maybeSingle(),
-    chiusurePerPeriodo(supabase, lunedi, venerdi),
+    chiusurePerPeriodo(supabase, lunedi, domenica),
   ]);
 
   const righePerGiorno = new Map((righeGiorni ?? []).map((r) => [r.data, r]));
@@ -57,8 +60,12 @@ export default async function OreLavoroPage() {
       data,
       etichetta: NOMI_GIORNI[giornoSettimanaIso(data)],
       dataBreve: formattaDataBreve(data),
+      // Solo informativo: il registro ore di lavoro non blocca la
+      // scrittura nei giorni di chiusura scolastica (specs/18, specs/53
+      // — a differenza di presenze/pasti, il personale può lavorare
+      // anche quando l'asilo non è operativo).
       chiuso: isGiornoChiuso(data, chiusure),
-      messaggioChiuso: messaggioChiusura(data, chiusure),
+      messaggioChiuso: notaGiornoChiusoOreLavoro(data, chiusure),
       stato: (salvata?.stato ?? 'lavorativo') as StatoGiornoOreLavoro,
       oreOrdinarie: salvata ? salvata.ore_ordinarie : oreOrdinariePreviste(profiloOrario, data),
       oreStraordinarie: salvata?.ore_straordinarie ?? 0,
@@ -68,7 +75,7 @@ export default async function OreLavoroPage() {
     };
   });
 
-  const totali = totaliSettimanaOreLavoro(righe.filter((r) => !r.chiuso));
+  const totali = totaliSettimanaOreLavoro(righe);
 
   return (
     <>
@@ -79,7 +86,7 @@ export default async function OreLavoroPage() {
             ← Torna alla dashboard
           </a>
           <h1 className="mt-2 text-lg font-medium">Ore di lavoro</h1>
-          <p className="mt-1 text-sm text-stone-600">Settimana {formattaIntervalloItaliano(lunedi, venerdi)}</p>
+          <p className="mt-1 text-sm text-stone-600">Settimana {formattaIntervalloItaliano(lunedi, domenica)}</p>
         </div>
 
         {confermata && (
@@ -96,57 +103,42 @@ export default async function OreLavoroPage() {
                   <span className="font-medium">
                     {r.etichetta} <span className="font-normal text-stone-600">{r.dataBreve}</span>
                   </span>
-                  {!r.chiuso && (
-                    <span className="text-sm text-stone-600">{ETICHETTE_STATO_ORE_LAVORO[r.stato]}</span>
-                  )}
+                  <span className="text-sm text-stone-600">{ETICHETTE_STATO_ORE_LAVORO[r.stato]}</span>
                 </div>
-                {r.chiuso && <p className="mt-1 text-sm text-stone-600">{r.messaggioChiuso}</p>}
-                {!r.chiuso && r.stato === 'lavorativo' && (
+                {r.chiuso && <p className="mt-1 text-xs text-stone-500">{r.messaggioChiuso}</p>}
+                {r.stato === 'lavorativo' && (
                   <p className="mt-1 text-sm text-stone-600">
                     Ordinarie: {r.oreOrdinarie}h · Straordinarie: {r.oreStraordinarie}h
                     {r.motivoStraordinario ? ` (${r.motivoStraordinario})` : ''}
                   </p>
                 )}
-                {!r.chiuso && r.stato === 'malattia' && (
+                {r.stato === 'malattia' && (
                   <p className="mt-1 text-sm text-stone-600">Codice malattia: {r.codiceMalattia}</p>
                 )}
-                {!r.chiuso && r.stato === 'assenza' && (
-                  <p className="mt-1 text-sm text-stone-600">Nota: {r.notaAssenza}</p>
-                )}
+                {r.stato === 'assenza' && <p className="mt-1 text-sm text-stone-600">Nota: {r.notaAssenza}</p>}
               </div>
             ))}
           </div>
         ) : (
           <FormConEsito action={salvaSettimanaOreLavoro} className="space-y-2">
             <input type="hidden" name="settimana_inizio" value={lunedi} />
-            {righe.map((r) =>
-              r.chiuso ? (
-                <div
-                  key={r.data}
-                  className="rounded-xl border border-dashed border-stone-300 bg-white p-3 text-sm text-stone-600"
-                >
-                  <span className="font-medium text-stone-800">
-                    {r.etichetta} {r.dataBreve}
-                  </span>{' '}
-                  — {r.messaggioChiuso}
-                </div>
-              ) : (
-                <RigaOreLavoro
-                  key={r.data}
-                  etichettaGiorno={r.etichetta}
-                  dataBreve={r.dataBreve}
-                  valori={{
-                    data: r.data,
-                    stato: r.stato,
-                    oreOrdinarie: r.oreOrdinarie,
-                    oreStraordinarie: r.oreStraordinarie,
-                    motivoStraordinario: r.motivoStraordinario,
-                    codiceMalattia: r.codiceMalattia,
-                    notaAssenza: r.notaAssenza,
-                  }}
-                />
-              )
-            )}
+            {righe.map((r) => (
+              <RigaOreLavoro
+                key={r.data}
+                etichettaGiorno={r.etichetta}
+                dataBreve={r.dataBreve}
+                messaggioChiuso={r.chiuso ? r.messaggioChiuso : null}
+                valori={{
+                  data: r.data,
+                  stato: r.stato,
+                  oreOrdinarie: r.oreOrdinarie,
+                  oreStraordinarie: r.oreStraordinarie,
+                  motivoStraordinario: r.motivoStraordinario,
+                  codiceMalattia: r.codiceMalattia,
+                  notaAssenza: r.notaAssenza,
+                }}
+              />
+            ))}
             <PulsanteInvio className="rounded-lg bg-emerald-700 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-800">
               Salva modifiche
             </PulsanteInvio>

--- a/components/RigaOreLavoro.tsx
+++ b/components/RigaOreLavoro.tsx
@@ -37,10 +37,15 @@ export function RigaOreLavoro({
   etichettaGiorno,
   dataBreve,
   valori,
+  messaggioChiuso = null,
 }: {
   etichettaGiorno: string;
   dataBreve: string;
   valori: ValoriGiornoOreLavoro;
+  // Solo informativo (specs/18, specs/53): il giorno resta pienamente
+  // modificabile anche quando l'asilo è chiuso, il personale può
+  // comunque lavorare — null quando il giorno non è chiuso.
+  messaggioChiuso?: string | null;
 }) {
   const [stato, setStato] = useState<StatoGiornoOreLavoro>(valori.stato);
   const nomeCampo = (suffisso: string) => `${suffisso}_${valori.data}`;
@@ -65,6 +70,8 @@ export function RigaOreLavoro({
           ))}
         </select>
       </div>
+
+      {messaggioChiuso && <p className="mt-1 text-xs text-stone-500">{messaggioChiuso}</p>}
 
       {stato === 'lavorativo' && (
         <div className="mt-2 flex flex-wrap gap-2">

--- a/e2e/18-report-ore-lavoro.spec.ts
+++ b/e2e/18-report-ore-lavoro.spec.ts
@@ -35,7 +35,7 @@ test.describe('18 — Report ore di lavoro', () => {
       await page.waitForURL('/dashboard', { timeout: 20_000 });
     });
 
-    test('form settimanale: precaricamento dal profilo orario, validazioni, salvataggio, conferma (senza premere Sì)', async ({
+    test('form settimanale: precaricamento dal profilo orario, validazioni, giorni chiusi lavorabili, conferma (senza premere Sì)', async ({
       page,
     }) => {
       const nomeProfilo = `E2E ore lavoro ${Date.now()}`;
@@ -62,15 +62,13 @@ test.describe('18 — Report ore di lavoro', () => {
           return;
         }
 
-        // Solo i giorni feriali sono mostrati (specs/18, specs/53).
-        await expect(page.getByText('Sabato', { exact: false })).toHaveCount(0);
-        await expect(page.getByText('Domenica', { exact: false })).toHaveCount(0);
-
-        const chiusi = await page.getByText('chiusura scolastica', { exact: false }).count();
-        test.skip(
-          chiusi > 0,
-          'questa settimana contiene un giorno di chiusura scolastica: i valori attesi dal test non sono validi'
-        );
+        // Tutti i 7 giorni sono mostrati ed editabili, sabato/domenica
+        // inclusi: il personale può lavorare anche nei giorni in cui
+        // l'asilo è chiuso (specs/18, specs/53 — nessun blocco, a
+        // differenza di presenze/pasti).
+        await expect(page.getByLabel('Stato Sabato')).toBeVisible();
+        await expect(page.getByLabel('Stato Domenica')).toBeVisible();
+        await expect(page.getByLabel('Ore ordinarie Sabato')).toBeEditable();
 
         await expect(page.getByRole('button', { name: 'Salva modifiche' })).toBeVisible();
         await expect(page.getByRole('button', { name: 'Conferma settimana' })).toBeVisible();
@@ -139,6 +137,15 @@ test.describe('18 — Report ore di lavoro', () => {
         await expect(page.getByLabel('Stato Mercoledì')).toHaveValue('assenza');
         await expect(page.getByLabel('Nota assenza Mercoledì')).toHaveValue('Visita E2E');
 
+        // Il personale può lavorare anche in un giorno di chiusura
+        // (qui sabato, chiusura implicita): l'inserimento è accettato,
+        // non bloccato (specs/18, specs/53).
+        await page.getByLabel('Ore ordinarie Sabato').fill('3');
+        await page.getByRole('button', { name: 'Salva modifiche' }).click();
+        await page.waitForTimeout(1000);
+        await page.reload();
+        await expect(page.getByLabel('Ore ordinarie Sabato')).toHaveValue('3');
+
         // "Conferma settimana" chiede conferma esplicita: verifico solo
         // che il dialogo compaia e che "Annulla" non confermi nulla (non
         // premo mai "Sì", vedi nota in testa al file).
@@ -149,9 +156,10 @@ test.describe('18 — Report ore di lavoro', () => {
         await page.getByRole('button', { name: 'Annulla' }).click();
         await expect(page.getByRole('button', { name: 'Salva modifiche' })).toBeVisible();
       } finally {
-        // Ripristino: martedì/mercoledì tornano lavorativo, l'account
-        // torna disabilitato e senza profilo, il profilo di test viene
-        // eliminato (svuota anche l'eventuale assegnazione, specs/54).
+        // Ripristino: martedì/mercoledì tornano lavorativo, sabato torna
+        // a 0 ore, l'account torna disabilitato e senza profilo, il
+        // profilo di test viene eliminato (svuota anche l'eventuale
+        // assegnazione, specs/54).
         const confermata = await page.getByText('Settimana confermata il', { exact: false }).count();
         if (!confermata) {
           await page.goto('/dashboard/ore-lavoro');
@@ -160,6 +168,9 @@ test.describe('18 — Report ore di lavoro', () => {
           }
           if ((await page.getByLabel('Stato Mercoledì').count()) > 0) {
             await page.getByLabel('Stato Mercoledì').selectOption('lavorativo');
+          }
+          if ((await page.getByLabel('Ore ordinarie Sabato').count()) > 0) {
+            await page.getByLabel('Ore ordinarie Sabato').fill('0');
           }
           const salva = page.getByRole('button', { name: 'Salva modifiche' });
           if ((await salva.count()) > 0) {

--- a/lib/date.test.ts
+++ b/lib/date.test.ts
@@ -7,7 +7,7 @@ import {
   formattaIntervalloItaliano,
   formattaMeseItaliano,
   giorniInRange,
-  giorniLavorativiSettimana,
+  giorniSettimana,
   giornoSettimanaIso,
   isUltimoGiornoMese,
   isUltimoGiornoSettimana,
@@ -228,24 +228,28 @@ describe('isWeekend', () => {
   });
 });
 
-describe('giorniLavorativiSettimana', () => {
-  it('restituisce i 5 giorni feriali lunedì-venerdì della settimana, partendo da un giorno feriale', () => {
-    expect(giorniLavorativiSettimana('2026-09-02')).toEqual([
+describe('giorniSettimana', () => {
+  it('restituisce i 7 giorni lunedì-domenica della settimana, partendo da un giorno feriale', () => {
+    expect(giorniSettimana('2026-09-02')).toEqual([
       '2026-08-31',
       '2026-09-01',
       '2026-09-02',
       '2026-09-03',
       '2026-09-04',
+      '2026-09-05',
+      '2026-09-06',
     ]);
   });
 
-  it('partendo da un weekend restituisce comunque i giorni feriali della stessa settimana ISO', () => {
-    expect(giorniLavorativiSettimana('2026-09-06')).toEqual([
+  it('partendo da un weekend restituisce comunque i 7 giorni della stessa settimana ISO', () => {
+    expect(giorniSettimana('2026-09-06')).toEqual([
       '2026-08-31',
       '2026-09-01',
       '2026-09-02',
       '2026-09-03',
       '2026-09-04',
+      '2026-09-05',
+      '2026-09-06',
     ]);
   });
 });

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -153,12 +153,12 @@ export function giorniInRange(inizio: string, fine: string): string[] {
   return giorni;
 }
 
-// I 5 giorni feriali (lunedì-venerdì) della settimana che contiene
-// `data` — usati dal report ore di lavoro (specs/18 -
-// report-ore-lavoro.md), che mostra/registra solo questi giorni: sabato
-// e domenica sono chiusura implicita (specs/53), coerente con i profili
-// orari (specs/54) che non prevedono ore in quei due giorni.
-export function giorniLavorativiSettimana(data: string): string[] {
+// I 7 giorni (lunedì-domenica) della settimana che contiene `data` —
+// usati dal report ore di lavoro (specs/18 - report-ore-lavoro.md), che
+// mostra/registra tutti i giorni: a differenza di presenze/pasti
+// (specs/53), il personale può lavorare anche nei giorni in cui l'asilo
+// è chiuso (weekend incluso).
+export function giorniSettimana(data: string): string[] {
   const lunedi = lunediSettimana(data);
-  return giorniInRange(lunedi, sommaGiorni(lunedi, 4));
+  return giorniInRange(lunedi, sommaGiorni(lunedi, 6));
 }

--- a/lib/oreLavoro.test.ts
+++ b/lib/oreLavoro.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { oreOrdinariePreviste, totaliSettimanaOreLavoro, validaGiornoOreLavoro, type InputGiornoOreLavoro } from './oreLavoro';
+import {
+  notaGiornoChiusoOreLavoro,
+  oreOrdinariePreviste,
+  totaliSettimanaOreLavoro,
+  validaGiornoOreLavoro,
+  type InputGiornoOreLavoro,
+} from './oreLavoro';
+import type { GiornoChiusura } from './calendarioScolastico';
 
 // Tutte funzioni pure (nessun I/O): specs/18 - report-ore-lavoro.md.
 
@@ -156,5 +163,34 @@ describe('totaliSettimanaOreLavoro', () => {
 
   it('nessun giorno dà totale zero', () => {
     expect(totaliSettimanaOreLavoro([])).toEqual({ ordinarie: 0, straordinarie: 0, totale: 0 });
+  });
+});
+
+describe('notaGiornoChiusoOreLavoro', () => {
+  it('null per un giorno feriale normale', () => {
+    expect(notaGiornoChiusoOreLavoro('2026-08-31', [])).toBeNull(); // lunedì
+  });
+
+  it('un sabato: nota generica "(weekend)", nessun blocco menzionato', () => {
+    const nota = notaGiornoChiusoOreLavoro('2026-09-05', []); // sabato
+    expect(nota).toContain('weekend');
+    expect(nota).toContain('puoi comunque registrare le ore');
+  });
+
+  it('un giorno di chiusura registrata senza nota', () => {
+    const chiusure: GiornoChiusura[] = [
+      { id: '1', dataInizio: '2026-12-23', dataFine: '2026-12-31', nota: null },
+    ];
+    const nota = notaGiornoChiusoOreLavoro('2026-12-27', chiusure);
+    expect(nota).toContain('Giorno di chiusura scolastica');
+    expect(nota).toContain('puoi comunque registrare le ore');
+  });
+
+  it('un giorno di chiusura registrata con nota la include', () => {
+    const chiusure: GiornoChiusura[] = [
+      { id: '1', dataInizio: '2026-12-23', dataFine: '2026-12-31', nota: 'Vacanze di Natale' },
+    ];
+    const nota = notaGiornoChiusoOreLavoro('2026-12-27', chiusure);
+    expect(nota).toContain('Vacanze di Natale');
   });
 });

--- a/lib/oreLavoro.ts
+++ b/lib/oreLavoro.ts
@@ -1,7 +1,21 @@
 import { formattaDataItaliana, giornoSettimanaIso } from '@/lib/date';
+import { isGiornoChiuso, trovaChiusura, type GiornoChiusura } from '@/lib/calendarioScolastico';
 import type { ProfiloOrario } from '@/lib/profiliOrari';
 
 export type StatoGiornoOreLavoro = 'lavorativo' | 'malattia' | 'assenza';
+
+// Nota puramente informativa per un giorno di chiusura scolastica nel
+// report ore di lavoro (specs/18, specs/53): a differenza del messaggio
+// usato in Presenze/Pasti (lib/calendarioScolastico.ts:messaggioChiusura,
+// che parla di un blocco reale), qui il giorno resta scrivibile — il
+// testo lo dice esplicitamente, per non suggerire un blocco che non
+// c'è. null se il giorno non è chiuso. Funzione pura, nessun I/O.
+export function notaGiornoChiusoOreLavoro(data: string, chiusure: GiornoChiusura[]): string | null {
+  if (!isGiornoChiuso(data, chiusure)) return null;
+  const chiusura = trovaChiusura(data, chiusure);
+  const dettaglio = chiusura ? (chiusura.nota ? `: ${chiusura.nota}` : '') : ' (weekend)';
+  return `Giorno di chiusura scolastica${dettaglio} — puoi comunque registrare le ore.`;
+}
 
 // Ore ordinarie previste per `data` dal profilo orario assegnato
 // all'utente (specs/54 - profili-orari.md), 0 se non ne ha uno

--- a/lib/versione.ts
+++ b/lib/versione.ts
@@ -4,5 +4,5 @@
 // ora, minuti e secondi (fuso Europe/Rome, non UTC — coerente con
 // lib/date.ts), non solo la data: utile per distinguere più rilasci
 // fatti nello stesso giorno.
-export const VERSIONE_APP = '0.15.0';
-export const DATA_BUILD = '2026-08-31 17:49:08';
+export const VERSIONE_APP = '0.15.1';
+export const DATA_BUILD = '2026-08-31 18:30:07';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "girasole",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "girasole",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "@supabase/ssr": "^0.5.1",
         "@supabase/supabase-js": "^2.45.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "girasole",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/specs/18 - report-ore-lavoro.md
+++ b/specs/18 - report-ore-lavoro.md
@@ -19,10 +19,12 @@ Dato che sono autenticata come personale abilitato al report ore, con un
 profilo orario assegnato (vedi
 [54 - profili-orari.md](54%20-%20profili-orari.md))
 Quando apro "Ore di lavoro"
-Allora vedo una tabella con una riga per ciascun giorno feriale
-(lunedì-venerdì) della settimana corrente
-E per ogni giorno il campo "Ore ordinarie" è precompilato con le ore
-previste dal mio profilo orario per quel giorno della settimana
+Allora vedo una tabella con una riga per ciascun giorno della settimana
+corrente, da lunedì a domenica
+E per i giorni lunedì-venerdì il campo "Ore ordinarie" è precompilato
+con le ore previste dal mio profilo orario per quel giorno della
+settimana; per sabato e domenica (non previsti dal profilo, vedi
+specs/54) parte da 0
 E vedo anche un campo "Ore straordinarie", a 0 di default
 
 ## Scenario: senza profilo orario assegnato le ore ordinarie partono da zero
@@ -83,13 +85,16 @@ Quando apro "Ore di lavoro"
 Allora vedo i dati della settimana in sola lettura (nessun campo
 modificabile, nessun pulsante "Salva modifiche" o "Conferma settimana")
 
-## Scenario: un giorno di chiusura scolastica non è modificabile
+## Scenario: il personale può registrare ore anche nei giorni di chiusura scolastica
 Dato che un giorno della settimana corrente è un giorno di chiusura
 scolastica (weekend, o un intervallo registrato dall'admin — vedi
 [53 - calendario-scolastico.md](53%20-%20calendario-scolastico.md))
 Quando apro "Ore di lavoro"
-Allora quel giorno mostra l'informazione di chiusura, senza alcun campo
-da compilare
+Allora quel giorno mostra comunque un'informazione di chiusura, ma resta
+pienamente modificabile: posso registrare ore ordinarie/straordinarie o
+malattia/assenza esattamente come per un giorno normale — il personale
+può lavorare (es. pulizie, attività amministrative, formazione) anche
+quando l'asilo non è operativo
 
 ## Scenario: accesso negato senza abilitazione
 Dato che il mio profilo non è abilitato al report ore
@@ -98,10 +103,14 @@ Allora vengo reindirizzata alla dashboard (vedi
 [17 - ore-di-lavoro.md](17%20-%20ore-di-lavoro.md))
 
 ## Regole
-- Solo i giorni feriali (lunedì-venerdì) della settimana corrente sono
-  mostrati: sabato e domenica sono chiusura implicita
-  (specs/53), coerente con i profili orari (specs/54) che non prevedono
-  ore in quei due giorni.
+- Tutti i 7 giorni della settimana corrente sono mostrati (lunedì-
+  domenica), non solo i feriali: a differenza di presenze/pasti
+  (specs/53), il registro ore di lavoro non considera sabato/domenica o
+  un giorno di chiusura registrato dall'admin come "non scrivibili" — il
+  personale può lavorare anche quando l'asilo non è operativo (es.
+  pulizie, attività amministrative, formazione). Un giorno di chiusura
+  mostra comunque l'informazione (stessa provenienza dati di specs/53),
+  a puro scopo informativo, senza bloccare nulla.
 - Un giorno è in uno di tre stati, esclusivi: **lavorativo** (ore
   ordinarie/straordinarie), **malattia** (richiede il codice ricevuto
   dal medico) o **assenza** (richiede una nota giustificativa). Passare
@@ -123,11 +132,6 @@ Allora vengo reindirizzata alla dashboard (vedi
   più modificare i giorni di quella settimana (RLS in
   `supabase/migrations/0025_report_ore_lavoro.sql`); l'admin sì, sempre
   — anche se non c'è ancora un'interfaccia per farlo (vedi Fuori scope).
-- Il blocco di un giorno di chiusura scolastica vale per QUALUNQUE ruolo,
-  admin incluso — stesso principio già in vigore per presenze e pasti
-  (specs/53): un asilo chiuso non ha ore di lavoro da registrare per
-  nessuno, non è un permesso di scrittura ma un vincolo di coerenza dei
-  dati. Imposto anche con un trigger sul database, non solo in UI.
 - Nessuna scrittura silenziosa: un salvataggio che fallisce la
   validazione (motivo/codice/nota mancante) non salva nessuno dei giorni
   di quel submit, nemmeno quelli validi — il personale corregge il

--- a/specs/53 - calendario-scolastico.md
+++ b/specs/53 - calendario-scolastico.md
@@ -7,8 +7,13 @@ assistente) vede l'informazione in Presenze e Pasti.
 ## Obiettivo
 Permettere all'admin di dichiarare i giorni in cui l'asilo è chiuso
 (vacanze, ponti, chiusure straordinarie), e impedire che in quei giorni
-— così come ogni sabato e domenica — vengano registrate presenze o pasti
-(in futuro anche ore di lavoro del personale).
+— così come ogni sabato e domenica — vengano registrate presenze o
+pasti. Le ore di lavoro del personale (vedi
+[18 - report-ore-lavoro.md](18%20-%20report-ore-lavoro.md)) sono
+un'eccezione deliberata: il personale può lavorare (es. pulizie,
+attività amministrative, formazione) anche quando l'asilo non è
+operativo, quindi quel registro mostra l'informazione di chiusura ma
+non blocca la scrittura.
 
 ## Scenario: creare un giorno di chiusura
 Dato che sono autenticato come admin
@@ -104,6 +109,8 @@ mio ruolo (admin incluso)
   inseriti dall'admin: intervalli sovrapposti sono innocui (il giorno
   risulta comunque chiuso), quindi non è un vincolo necessario per il
   comportamento descritto sopra.
-- In futuro, lo stesso vincolo si applicherà anche alla registrazione
-  delle ore di lavoro del personale (fuori dallo scope di questa fase,
-  che non ha ancora quella funzionalità).
+- Il registro ore di lavoro del personale
+  ([18 - report-ore-lavoro.md](18%20-%20report-ore-lavoro.md)) mostra
+  la stessa informazione di chiusura ma **non** applica questo blocco:
+  scelta esplicita, non un'omissione — il personale può lavorare anche
+  nei giorni in cui l'asilo è chiuso.

--- a/supabase/migrations/0026_ore_lavoro_permesse_giorni_chiusi.sql
+++ b/supabase/migrations/0026_ore_lavoro_permesse_giorni_chiusi.sql
@@ -1,0 +1,19 @@
+-- Girasole — Le ore di lavoro del personale si possono registrare anche
+-- nei giorni in cui l'asilo è chiuso (weekend o chiusura registrata
+-- dall'admin): richiesta esplicita dell'utente. Corregge
+-- 0025_report_ore_lavoro.sql, che — riprendendo la nota "in futuro"
+-- lasciata in 0022_calendario_scolastico.sql/specs/53 — aveva esteso lo
+-- stesso blocco già in vigore per presenze/pasti anche alle ore di
+-- lavoro. Il personale può lavorare (pulizie, attività amministrative,
+-- formazione...) anche quando l'asilo non è operativo: vedi
+-- specs/18 - report-ore-lavoro.md e la nota aggiornata in specs/53.
+--
+-- L'informazione di chiusura resta visibile in UI (a scopo puramente
+-- informativo, lib/calendarioScolastico.ts), solo il blocco a livello
+-- di trigger viene rimosso qui.
+--
+-- Incolla questo file nel SQL Editor di Supabase (dopo
+-- 0025_report_ore_lavoro.sql) ed eseguilo una volta sola.
+
+drop trigger if exists ore_lavoro_giorni_blocca_se_chiuso on public.ore_lavoro_giorni;
+drop function if exists public.impedisci_ore_lavoro_giorno_chiuso();


### PR DESCRIPTION
## Summary
- Richiesta esplicita: il personale può lavorare (pulizie, attività amministrative, formazione...) anche nei giorni in cui l'asilo è chiuso (weekend o chiusura registrata dall'admin). Corregge v0.15.0, che aveva esteso alle ore di lavoro lo stesso blocco già in vigore per presenze/pasti (riprendendo una nota "in futuro" lasciata in `specs/53`/`0022_calendario_scolastico.sql`) — non corretto per questo registro.
- `/dashboard/ore-lavoro` mostra ora tutti i 7 giorni della settimana corrente (non solo lunedì-venerdì), tutti pienamente modificabili. Un giorno di chiusura scolastica mostra comunque un'informazione (testo dedicato, non più il messaggio di blocco di presenze/pasti — fuorviante qui), ma non blocca nulla.
- Nuova migration `0026_ore_lavoro_permesse_giorni_chiusi.sql` (non modifica la 0025 già applicata) rimuove il trigger `ore_lavoro_giorni_blocca_se_chiuso` e la funzione `impedisci_ore_lavoro_giorno_chiuso`.
- `specs/18` e `specs/53` aggiornate di conseguenza (l'eccezione per le ore di lavoro è ora dichiarata esplicitamente).
- `lib/date.ts:giorniLavorativiSettimana` (5 giorni) sostituita da `giorniSettimana` (7 giorni). Nuova `lib/oreLavoro.ts:notaGiornoChiusoOreLavoro` (pura, con unit test).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx next lint`
- [x] `npx vitest run` (173 test, inclusi i nuovi unit test di `notaGiornoChiusoOreLavoro` e l'aggiornamento di `giorniSettimana`)
- [x] `npx jscpd` (nessun nuovo duplicato — i 3 clone segnalati sono preesistenti)
- [ ] `npx playwright test e2e/18-report-ore-lavoro.spec.ts` dal tuo ambiente locale (non eseguibile in questo ambiente sandbox). Aggiornato: verifica ora che sabato/domenica siano editabili e che inserire ore di sabato sia accettato (non bloccato). Stessa cautela di v0.15.0: non preme mai "Sì" su "Conferma settimana".

## Da fare dopo il merge
- Applicare `supabase/migrations/0026_ore_lavoro_permesse_giorni_chiusi.sql` nel SQL Editor di Supabase (progetto di test e produzione) — senza, il trigger continua a bloccare le ore nei giorni di chiusura.

---
_Generated by [Claude Code](https://claude.ai/code/session_0165puuH5x8UEN9SYds2KVhF)_