### PR TITLE
Allarmi: presenze/pasti entro mezzogiorno, settimana ore non confermata (v0.17.0)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1320,6 +1320,78 @@ Due bug segnalati dopo l'uso reale di `/admin/maestre`.
       (179 test, +6 nuovi in `lib/navigazione.test.ts`) e `npx jscpd`
       (3 clone preesistenti, sotto soglia, nessuno nuovo) puliti.
 
+## Allarmi: presenze/pasti entro mezzogiorno, settimana ore non confermata (v0.17.0)
+- [x] Richiesta dell'utente: due allarmi, ciascuno su due canali (banner
+      in dashboard + email). 1) Se entro le 12:00 (Europe/Rome) di un
+      giorno attivo non sono state segnate tutte le presenze o non sono
+      stati confermati i pasti (comunicazione a Rojac, specs/16),
+      banner per **tutto** lo staff ed email a
+      `info@asilosartorio.it`. 2) Per ogni utente abilitato al report
+      ore (specs/17) la cui settimana scorsa non risulta confermata
+      (specs/18), banner **personale** ed email allo stesso indirizzo
+      (il secondo indirizzo scritto nel messaggio dell'utente,
+      "asilosaetoeio.it", era un refuso — uso lo stesso
+      `info@asilosartorio.it`/`REPORT_EMAIL_DESTINATARIO` già in uso
+      per i report notturni).
+- [x] Nuovo `specs/07 - allarmi.md` (in indice su `specs/00`, numerato
+      0x perché trasversale come specs/06).
+- [x] `supabase/migrations/0027_allarmi.sql`: nuova tabella
+      `allarmi_inviati` (`tipo`, `chiave`, `inviato_at` — esistenza
+      della riga = già inviato, stesso pattern di
+      `report_giornalieri_inviati`/`ore_lavoro_settimane`), un'unica
+      tabella con discriminatore invece di una per allarme. RLS
+      abilitata senza policy per `authenticated`: solo il cron
+      (service_role) la usa.
+- [x] `lib/allarmi.ts` (nuovo): funzioni pure `dopoMezzogiorno`,
+      `allarmeMezzogiornoAttivo`, `descrizioneStatoOperativo` (unit
+      test in `lib/allarmi.test.ts`, incluso il confine ora
+      solare/legale) e funzioni I/O `calcolaStatoOperativoGiorno`
+      (richiede la service_role key: serve vedere tutte le sezioni, non
+      solo quelle di chi guarda — stesso motivo di specs/52),
+      `settimanaPrecedenteConfermata` (RLS normale: un utente legge
+      solo la propria riga) e `utentiConSettimanaNonConfermata` (solo
+      cron). `lib/date.ts:settimanaPrecedente` (nuova, con unit test).
+- [x] Nuova route `app/api/cron/allarmi/route.ts` — un solo cron
+      (non due) per restare dentro il limite Vercel Hobby di 2 cron per
+      progetto (già a 1 con `report-presenze`), pianificato dopo
+      mezzogiorno Europe/Rome (`vercel.json`, `"30 11 * * *"` UTC, dopo
+      le 12:00 Rome sia in ora solare sia legale). Valuta entrambi gli
+      allarmi, invia le email (idempotenti per tipo+chiave),
+      protetto dallo stesso `CRON_SECRET` degli altri cron — nuovo
+      `lib/auth.ts:autorizzaCron`, condiviso con
+      `report-presenze/route.ts` per non duplicare quel controllo in
+      due file (CLAUDE.md, jscpd). `lib/email.ts:destinatarioNotifiche`
+      (nuovo) sostituisce la funzione locale `destinatarioReport` di
+      `report-presenze/route.ts`, stesso motivo.
+- [x] `app/dashboard/page.tsx`: due banner (`role="alert"`) in cima al
+      `<main>`, prima di tutto il resto — quello mezzogiorno (rosso,
+      calcolato con la service_role key) e quello settimana ore
+      (ambra, personale, calcolato con la sessione RLS normale
+      dell'utente). Il banner personale non promette di poter
+      confermare la settimana scorsa da qui (specs/18 non lo permette
+      ancora, solo la settimana corrente): invita a contattare l'admin.
+- [x] Verificato: `npx tsc --noEmit`, `npx next lint`, `npx vitest run`
+      (198 test) e `npx jscpd` (3 clone preesistenti, sotto soglia,
+      nessuno nuovo) puliti. Nuovo `e2e/07-allarmi.spec.ts` — non
+      eseguibile in questo ambiente sandbox (nessun dev server né
+      credenziali Supabase): diversi scenari dipendono dall'ora reale o
+      dallo stato reale dei dati e si saltano da soli quando non
+      verificabili al momento (stessa cautela di
+      53-calendario-scolastico.spec.ts), da eseguire più volte in
+      momenti diversi della giornata dal tuo ambiente locale per
+      coprirli tutti. Include anche i test della route cron
+      (401 senza secret, idempotenza) sul modello di
+      52-report-email-automatico.spec.ts.
+- [ ] **Da fare da parte tua**:
+      1) applica `supabase/migrations/0027_allarmi.sql` nel SQL Editor
+      di Supabase (test e produzione) prima che il cron/i banner
+      funzionino;
+      2) su Vercel, il nuovo cron in `vercel.json` (`/api/cron/allarmi`)
+      viene registrato automaticamente al prossimo deploy — verifica
+      però che il piano Vercel copra 2 cron job (Hobby ne consente 2,
+      ci arriviamo esattamente con questo); se in futuro serve un terzo
+      cron, servirà valutare un piano superiore o accorpare ulteriormente.
+
 ## Backlog — Fase 2/3
 - [ ] Rette mensili e stato pagamento
 - [ ] Portale genitori (UI dedicata)

--- a/app/api/cron/allarmi/route.ts
+++ b/app/api/cron/allarmi/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from 'next/server';
+import { autorizzaCron } from '@/lib/auth';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { inviaEmail, destinatarioNotifiche } from '@/lib/email';
+import { oggi, formattaDataItaliana, formattaIntervalloItaliano, settimanaPrecedente } from '@/lib/date';
+import { chiusuraPerData, isGiornoChiuso } from '@/lib/calendarioScolastico';
+import {
+  dopoMezzogiorno,
+  allarmeMezzogiornoAttivo,
+  calcolaStatoOperativoGiorno,
+  descrizioneStatoOperativo,
+  utentiConSettimanaNonConfermata,
+} from '@/lib/allarmi';
+
+export const dynamic = 'force-dynamic';
+
+// Vercel Cron chiama questa route una volta al giorno dopo mezzogiorno
+// Europe/Rome (vedi vercel.json: "30 11 * * *" UTC, che cade sempre
+// dopo le 12:00 Rome sia in ora solare sia legale — specs/07 -
+// allarmi.md). Protetta dallo stesso secret degli altri cron
+// (Authorization: Bearer $CRON_SECRET).
+export async function GET(request: Request) {
+  if (!autorizzaCron(request)) {
+    return NextResponse.json({ errore: 'non autorizzato' }, { status: 401 });
+  }
+
+  const supabase = createAdminClient();
+  const adesso = new Date();
+  const dataOggi = oggi();
+
+  const risultati = {
+    mezzogiorno: 'non_applicabile' as 'non_applicabile' | 'inviato' | 'gia_inviato',
+    settimanaOre: [] as string[],
+  };
+
+  // Allarme 1: presenze/pasti non completati entro mezzogiorno
+  // (specs/07). Il vincolo "giorno attivo" è lo stesso di presenze/pasti
+  // (specs/53); una volta appurato, lo stato operativo richiede la
+  // service_role key per vedere tutte le sezioni (non solo quelle di un
+  // singolo utente).
+  const chiusuraOggi = await chiusuraPerData(supabase, dataOggi);
+  const giornoAttivo = !isGiornoChiuso(dataOggi, chiusuraOggi ? [chiusuraOggi] : []);
+  if (giornoAttivo && dopoMezzogiorno(adesso)) {
+    const stato = await calcolaStatoOperativoGiorno(supabase, dataOggi);
+    if (allarmeMezzogiornoAttivo(adesso, giornoAttivo, stato)) {
+      const { data: giaInviato } = await supabase
+        .from('allarmi_inviati')
+        .select('id')
+        .eq('tipo', 'presenze_pasti_mezzogiorno')
+        .eq('chiave', dataOggi)
+        .maybeSingle();
+
+      if (giaInviato) {
+        risultati.mezzogiorno = 'gia_inviato';
+      } else {
+        await inviaEmail({
+          a: destinatarioNotifiche(),
+          oggetto: `Allarme: presenze/pasti non completati — ${formattaDataItaliana(dataOggi)}`,
+          html: `<p>Alle ore attuali di ${formattaDataItaliana(dataOggi)}, ${descrizioneStatoOperativo(stato)}. Verifica appena possibile.</p>`,
+        });
+        await supabase.from('allarmi_inviati').insert({ tipo: 'presenze_pasti_mezzogiorno', chiave: dataOggi });
+        risultati.mezzogiorno = 'inviato';
+      }
+    }
+  }
+
+  // Allarme 2: settimana di ore di lavoro non confermata (specs/07),
+  // un'email per ogni utente abilitato che non ha confermato la
+  // settimana appena conclusa.
+  const { inizio: settimanaInizio, fine: settimanaFine } = settimanaPrecedente(dataOggi);
+  const utenti = await utentiConSettimanaNonConfermata(supabase, settimanaInizio);
+
+  for (const utente of utenti) {
+    const chiave = `${utente.utenteId}_${settimanaInizio}`;
+    const { data: giaInviato } = await supabase
+      .from('allarmi_inviati')
+      .select('id')
+      .eq('tipo', 'settimana_ore_non_confermata')
+      .eq('chiave', chiave)
+      .maybeSingle();
+    if (giaInviato) continue;
+
+    await inviaEmail({
+      a: destinatarioNotifiche(),
+      oggetto: `Allarme: settimana ore non confermata — ${utente.nome} ${utente.cognome}`,
+      html: `<p>${utente.nome} ${utente.cognome} (${utente.email}) non ha ancora confermato le ore della settimana ${formattaIntervalloItaliano(settimanaInizio, settimanaFine)}.</p>`,
+    });
+    await supabase.from('allarmi_inviati').insert({ tipo: 'settimana_ore_non_confermata', chiave });
+    risultati.settimanaOre.push(utente.email);
+  }
+
+  return NextResponse.json({ ok: true, data: dataOggi, risultati });
+}

--- a/app/api/cron/report-presenze/route.ts
+++ b/app/api/cron/report-presenze/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
+import { autorizzaCron } from '@/lib/auth';
 import { createAdminClient } from '@/lib/supabase/admin';
-import { inviaEmail, type AllegatoEmail } from '@/lib/email';
+import { inviaEmail, destinatarioNotifiche, type AllegatoEmail } from '@/lib/email';
 import {
   generaTabellaGiornalieraHtml,
   aggregaReportPeriodoTutteLeClassi,
@@ -23,15 +24,9 @@ import {
   isUltimoGiornoMese,
 } from '@/lib/date';
 
-const DESTINATARIO_DEFAULT = 'info@asilosartorio.it';
-
 export const dynamic = 'force-dynamic';
 
 type TipoReportNotturno = 'giornaliero' | 'settimanale' | 'mensile';
-
-function destinatarioReport(): string {
-  return process.env.REPORT_EMAIL_DESTINATARIO || DESTINATARIO_DEFAULT;
-}
 
 // specs/52 - report-email-automatico.md: 'sempre' (default) ricalcola e
 // invia settimanale/mensile ogni notte "a tutt'oggi"; 'fine_periodo' li
@@ -112,12 +107,8 @@ async function allegatoGiornaliero(data: string): Promise<AllegatoEmail> {
 // invia in automatico in Authorization: Bearer $CRON_SECRET quando la
 // variabile d'ambiente CRON_SECRET è configurata sul progetto.
 export async function GET(request: Request) {
-  const secret = process.env.CRON_SECRET;
-  if (secret) {
-    const auth = request.headers.get('authorization');
-    if (auth !== `Bearer ${secret}`) {
-      return NextResponse.json({ errore: 'non autorizzato' }, { status: 401 });
-    }
+  if (!autorizzaCron(request)) {
+    return NextResponse.json({ errore: 'non autorizzato' }, { status: 401 });
   }
 
   // Il cron gira poco dopo la mezzanotte Rome: oggi() è già il nuovo
@@ -197,7 +188,7 @@ export async function GET(request: Request) {
       : `<p>In allegato: ${daPreparare.map((d) => d.tipo).join(', ')}.</p>`;
 
     await inviaEmail({
-      a: destinatarioReport(),
+      a: destinatarioNotifiche(),
       oggetto: `Report del ${formattaDataItaliana(dataReport)}`,
       html: htmlGiornaliero,
       allegati,

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -5,9 +5,18 @@ import { PulsanteInvio } from '@/components/PulsanteInvio';
 import { SelettoreData } from '@/components/SelettoreData';
 import { SelettoreDestinatarioAvviso } from '@/components/SelettoreDestinatarioAvviso';
 import { requireProfilo } from '@/lib/auth';
-import { oggi } from '@/lib/date';
+import { oggi, settimanaPrecedente, formattaIntervalloItaliano } from '@/lib/date';
 import { sezioniAttiveVisibili, bambiniAttiviVisibili } from '@/lib/sezioni';
 import { cardsDashboard } from '@/lib/dashboardSezioni';
+import { chiusuraPerData, isGiornoChiuso } from '@/lib/calendarioScolastico';
+import {
+  dopoMezzogiorno,
+  allarmeMezzogiornoAttivo,
+  calcolaStatoOperativoGiorno,
+  descrizioneStatoOperativo,
+  settimanaPrecedenteConfermata,
+} from '@/lib/allarmi';
+import { createAdminClient } from '@/lib/supabase/admin';
 import { creaPromemoria } from './actions';
 
 export const dynamic = 'force-dynamic';
@@ -41,6 +50,31 @@ export default async function DashboardPage({
   const haSezioni = ruolo === 'admin' || sezioni.length > 0;
   const cards = cardsDashboard({ data, haSezioni, ruolo, abilitatoOreLavoro: profilo?.abilitato_ore_lavoro });
 
+  // Allarme 1 (specs/07 - allarmi.md): presenze/pasti non completati
+  // entro mezzogiorno, per TUTTO l'asilo — richiede la service_role key
+  // per vedere le sezioni al di là di quelle dell'utente corrente
+  // (stesso motivo del report notturno, specs/52).
+  const oraAttuale = new Date();
+  const chiusuraOggi = await chiusuraPerData(supabase, oggi());
+  const giornoAttivoOggi = !isGiornoChiuso(oggi(), chiusuraOggi ? [chiusuraOggi] : []);
+  let descrizioneAllarmeMezzogiorno: string | null = null;
+  if (giornoAttivoOggi && dopoMezzogiorno(oraAttuale)) {
+    const statoOperativo = await calcolaStatoOperativoGiorno(createAdminClient(), oggi());
+    if (allarmeMezzogiornoAttivo(oraAttuale, giornoAttivoOggi, statoOperativo)) {
+      descrizioneAllarmeMezzogiorno = descrizioneStatoOperativo(statoOperativo);
+    }
+  }
+
+  // Allarme 2 (specs/07): la mia settimana di ore di lavoro scorsa non
+  // confermata — solo per me (RLS sulla mia sessione, nessun bisogno
+  // della service_role key qui).
+  const settimanaOreScorsa = settimanaPrecedente(oggi());
+  let mostraAllarmeSettimanaOre = false;
+  if (profilo?.abilitato_ore_lavoro) {
+    const confermata = await settimanaPrecedenteConfermata(supabase, user.id, settimanaOreScorsa.inizio);
+    mostraAllarmeSettimanaOre = !confermata;
+  }
+
   const bambini = await bambiniAttiviVisibili(
     supabase,
     ruolo,
@@ -56,6 +90,23 @@ export default async function DashboardPage({
   return (
     <NavHeader nome={nomeVisualizzato} ruolo={ruolo}>
       <main className="mx-auto max-w-3xl space-y-10 px-4 py-8">
+        {descrizioneAllarmeMezzogiorno && (
+          <div role="alert" className="rounded-xl border border-red-300 bg-red-50 p-4 text-sm text-red-900">
+            <p className="font-semibold">⚠️ Presenze e/o pasti di oggi non risultano completati</p>
+            <p className="mt-1">Sono le 12:00 passate e {descrizioneAllarmeMezzogiorno}. Verifica appena possibile.</p>
+          </div>
+        )}
+
+        {mostraAllarmeSettimanaOre && (
+          <div role="alert" className="rounded-xl border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900">
+            <p className="font-semibold">⏰ Non hai confermato le ore della settimana scorsa</p>
+            <p className="mt-1">
+              Settimana {formattaIntervalloItaliano(settimanaOreScorsa.inizio, settimanaOreScorsa.fine)}. Contatta
+              l&apos;amministratore per regolarizzarla.
+            </p>
+          </div>
+        )}
+
         {ruolo === 'admin' && (
           <div className="rounded-xl border border-dashed border-stone-300 p-4 text-sm text-stone-600">
             Per creare sezioni e bambini o gestire gli utenti vai su{' '}

--- a/e2e/07-allarmi.spec.ts
+++ b/e2e/07-allarmi.spec.ts
@@ -1,0 +1,168 @@
+// Requisito: specs/07 - allarmi.md
+//
+// ATTENZIONE: alcuni scenari dipendono dall'ora reale (Europe/Rome) e
+// dallo stato reale di presenze/pasti sul progetto Supabase di test, che
+// questa suite non può forzare senza rischiare di interferire con altri
+// file e2e che scrivono su "oggi" (stessa cautela di
+// 53-calendario-scolastico.spec.ts). Dove non è possibile controllare la
+// condizione, il test si salta da solo con `test.skip` invece di fallire
+// o di dare un falso positivo — coerente con la suite esistente.
+//
+// Il test dell'allarme "settimana ore non confermata" modifica
+// temporaneamente l'account admin di test (abilitazione al report ore)
+// e lo ripristina in `finally` — stesso pattern di
+// 17-ore-di-lavoro.spec.ts e 18-report-ore-lavoro.spec.ts.
+import { test, expect } from '@playwright/test';
+import { dataOggiRoma, hasCredenziali, nessunaViolazioneA11yGrave, statoAutenticazione } from './helpers';
+
+function oraRomaAdesso(): number {
+  return Number(
+    new Intl.DateTimeFormat('en-GB', { timeZone: 'Europe/Rome', hour: '2-digit', hourCycle: 'h23' }).format(new Date())
+  );
+}
+
+function oggiEGiornoFeriale(): boolean {
+  const [anno, mese, giorno] = dataOggiRoma().split('-').map(Number);
+  const giornoSettimana = new Date(Date.UTC(anno, mese - 1, giorno, 12)).getUTCDay();
+  return giornoSettimana !== 0 && giornoSettimana !== 6;
+}
+
+const TESTO_BANNER_MEZZOGIORNO = 'non risultano completati';
+const TESTO_BANNER_SETTIMANA_ORE = 'Non hai confermato le ore della settimana scorsa';
+
+test.describe('07 — Allarmi', () => {
+  test.describe('presenze/pasti non completati entro mezzogiorno', () => {
+    test.describe('come maestra', () => {
+      test.use({ storageState: statoAutenticazione('maestra') });
+
+      test.beforeEach(async ({ page }) => {
+        test.skip(!hasCredenziali('maestra'), 'richiede E2E_MAESTRA_EMAIL/PASSWORD');
+      });
+
+      test('prima delle 12:00 il banner non compare', async ({ page }) => {
+        test.skip(
+          oraRomaAdesso() >= 12,
+          'la suite gira dopo mezzogiorno: lo scenario "prima di mezzogiorno" non è verificabile ora'
+        );
+
+        await page.goto('/dashboard');
+        await expect(page.getByText(TESTO_BANNER_MEZZOGIORNO, { exact: false })).toHaveCount(0);
+      });
+
+      test('in un giorno di chiusura (weekend) il banner non compare, anche dopo mezzogiorno', async ({ page }) => {
+        test.skip(
+          oggiEGiornoFeriale(),
+          'oggi non è un weekend: lo scenario "giorno di chiusura" non è verificabile ora'
+        );
+
+        await page.goto('/dashboard');
+        await expect(page.getByText(TESTO_BANNER_MEZZOGIORNO, { exact: false })).toHaveCount(0);
+      });
+
+      test('dopo le 12:00 in un giorno feriale, se compare il banner ha un contenuto coerente ed è visibile anche all\'admin', async ({
+        page,
+        browser,
+      }) => {
+        test.skip(!hasCredenziali('admin'), 'richiede anche E2E_ADMIN_EMAIL/PASSWORD');
+        test.skip(oraRomaAdesso() < 12 || !oggiEGiornoFeriale(), 'verificabile solo dopo mezzogiorno in un giorno feriale');
+
+        await page.goto('/dashboard');
+        const banner = page.getByRole('alert').filter({ hasText: TESTO_BANNER_MEZZOGIORNO });
+        const presente = (await banner.count()) > 0;
+        test.skip(!presente, 'oggi presenze e pasti risultano già completati: nessuna anomalia da verificare ora');
+
+        await expect(banner).toContainText('12:00');
+        await nessunaViolazioneA11yGrave(page);
+
+        // È una situazione dell'intero asilo, non delle sole sezioni
+        // della maestra: lo stesso banner deve comparire anche all'admin.
+        const contestoAdmin = await browser.newContext({ storageState: statoAutenticazione('admin') });
+        const paginaAdmin = await contestoAdmin.newPage();
+        await paginaAdmin.goto('/dashboard');
+        await expect(paginaAdmin.getByRole('alert').filter({ hasText: TESTO_BANNER_MEZZOGIORNO })).toBeVisible();
+        await contestoAdmin.close();
+      });
+    });
+  });
+
+  test.describe('settimana di ore di lavoro non confermata', () => {
+    test.describe('come admin', () => {
+      test.use({ storageState: statoAutenticazione('admin') });
+
+      test.beforeEach(async ({ page }) => {
+        test.skip(!hasCredenziali('admin'), 'richiede E2E_ADMIN_EMAIL/PASSWORD');
+      });
+
+      test('senza abilitazione al report ore, nessun banner personale', async ({ page }) => {
+        await page.goto('/dashboard');
+        await expect(page.getByText(TESTO_BANNER_SETTIMANA_ORE, { exact: false })).toHaveCount(0);
+      });
+
+      test('abilitata senza aver mai confermato una settimana, il banner compare; scompare disabilitando', async ({
+        page,
+      }) => {
+        await page.goto('/admin/maestre');
+        const riga = page.locator('li', { hasText: process.env.E2E_ADMIN_EMAIL! });
+        await riga.getByLabel('Ore di lavoro').check();
+        await riga.getByRole('button', { name: 'Aggiorna' }).click();
+        await page.waitForTimeout(1000);
+
+        try {
+          await page.goto('/dashboard');
+          const banner = page.getByText(TESTO_BANNER_SETTIMANA_ORE, { exact: false });
+          const presente = (await banner.count()) > 0;
+          test.skip(
+            !presente,
+            'la settimana scorsa risulta già confermata per questo account (es. verificata manualmente in passato) — nessuna funzione per "sconfermarla" in questa fase'
+          );
+
+          await expect(banner).toBeVisible();
+          await nessunaViolazioneA11yGrave(page);
+        } finally {
+          await page.goto('/admin/maestre');
+          const rigaRipristina = page.locator('li', { hasText: process.env.E2E_ADMIN_EMAIL! });
+          await rigaRipristina.getByLabel('Ore di lavoro').uncheck();
+          await rigaRipristina.getByRole('button', { name: 'Aggiorna' }).click();
+          await page.waitForTimeout(1000);
+        }
+      });
+    });
+  });
+
+  test.describe('cron /api/cron/allarmi', () => {
+    test('senza il secret corretto la route rifiuta la richiesta', async ({ request }) => {
+      test.skip(!process.env.CRON_SECRET, 'richiede CRON_SECRET configurato per avere qualcosa da verificare');
+
+      const risposta = await request.get('/api/cron/allarmi', {
+        headers: { Authorization: 'Bearer secret-sbagliato' },
+      });
+      expect(risposta.status()).toBe(401);
+    });
+
+    test('il job invocato due volte non invia due volte la stessa email (idempotenza)', async ({ request }) => {
+      test.skip(
+        !process.env.CRON_SECRET || !process.env.RESEND_API_KEY,
+        'richiede CRON_SECRET e RESEND_API_KEY configurate per invocare davvero la route del cron'
+      );
+
+      const intestazioni = { Authorization: `Bearer ${process.env.CRON_SECRET}` };
+
+      const prima = await request.get('/api/cron/allarmi', { headers: intestazioni });
+      expect(prima.ok()).toBe(true);
+      const corpo1 = await prima.json();
+
+      const seconda = await request.get('/api/cron/allarmi', { headers: intestazioni });
+      expect(seconda.ok()).toBe(true);
+      const corpo2 = await seconda.json();
+
+      if (corpo1.risultati.mezzogiorno === 'inviato' || corpo1.risultati.mezzogiorno === 'gia_inviato') {
+        expect(corpo2.risultati.mezzogiorno).toBe('gia_inviato');
+      }
+      // Ogni email inviata dalla prima chiamata non deve ricomparire
+      // nella seconda: è già tracciata in allarmi_inviati.
+      for (const email of corpo1.risultati.settimanaOre) {
+        expect(corpo2.risultati.settimanaOre).not.toContain(email);
+      }
+    });
+  });
+});

--- a/lib/allarmi.test.ts
+++ b/lib/allarmi.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+  dopoMezzogiorno,
+  allarmeMezzogiornoAttivo,
+  descrizioneStatoOperativo,
+  type StatoOperativoGiorno,
+} from './allarmi';
+
+// Solo le funzioni pure di questo modulo (nessun I/O) — vedi CLAUDE.md,
+// criterio unit test: calcolaStatoOperativoGiorno/
+// settimanaPrecedenteConfermata/utentiConSettimanaNonConfermata fanno
+// query Supabase, coperte solo da e2e.
+
+// Un istante alle 12:00 Europe/Rome corrisponde a 11:00 UTC in inverno
+// (CET, UTC+1) e 10:00 UTC in estate (CEST, UTC+2).
+describe('dopoMezzogiorno', () => {
+  it('vero esattamente a mezzogiorno (inverno, CET)', () => {
+    expect(dopoMezzogiorno(new Date('2026-01-15T11:00:00Z'))).toBe(true);
+  });
+
+  it('falso un minuto prima di mezzogiorno (inverno, CET)', () => {
+    expect(dopoMezzogiorno(new Date('2026-01-15T10:59:00Z'))).toBe(false);
+  });
+
+  it('vero dopo mezzogiorno in estate (CEST, UTC+2)', () => {
+    expect(dopoMezzogiorno(new Date('2026-07-15T10:00:00Z'))).toBe(true);
+  });
+
+  it('falso prima di mezzogiorno in estate (CEST, UTC+2)', () => {
+    expect(dopoMezzogiorno(new Date('2026-07-15T09:59:00Z'))).toBe(false);
+  });
+
+  it('vero nel tardo pomeriggio', () => {
+    expect(dopoMezzogiorno(new Date('2026-01-15T18:00:00Z'))).toBe(true);
+  });
+});
+
+function stato(sovrascrizioni: Partial<StatoOperativoGiorno> = {}): StatoOperativoGiorno {
+  return { nessunDatoAtteso: false, presenzeIncomplete: false, pastiNonConfermati: false, ...sovrascrizioni };
+}
+
+const MEZZOGIORNO_INVERNO = new Date('2026-01-15T11:00:00Z');
+const MATTINA_INVERNO = new Date('2026-01-15T09:00:00Z');
+
+describe('allarmeMezzogiornoAttivo', () => {
+  it('falso prima di mezzogiorno, anche con presenze/pasti mancanti', () => {
+    expect(allarmeMezzogiornoAttivo(MATTINA_INVERNO, true, stato({ presenzeIncomplete: true }))).toBe(false);
+  });
+
+  it('falso se il giorno non è attivo (chiuso), anche dopo mezzogiorno', () => {
+    expect(allarmeMezzogiornoAttivo(MEZZOGIORNO_INVERNO, false, stato({ presenzeIncomplete: true }))).toBe(false);
+  });
+
+  it('falso se non ci sono classi/bambini attivi', () => {
+    expect(allarmeMezzogiornoAttivo(MEZZOGIORNO_INVERNO, true, stato({ nessunDatoAtteso: true }))).toBe(false);
+  });
+
+  it('falso dopo mezzogiorno se tutto è completo', () => {
+    expect(allarmeMezzogiornoAttivo(MEZZOGIORNO_INVERNO, true, stato())).toBe(false);
+  });
+
+  it('vero dopo mezzogiorno con presenze incomplete', () => {
+    expect(allarmeMezzogiornoAttivo(MEZZOGIORNO_INVERNO, true, stato({ presenzeIncomplete: true }))).toBe(true);
+  });
+
+  it('vero dopo mezzogiorno con pasti non confermati', () => {
+    expect(allarmeMezzogiornoAttivo(MEZZOGIORNO_INVERNO, true, stato({ pastiNonConfermati: true }))).toBe(true);
+  });
+
+  it('vero dopo mezzogiorno con entrambi mancanti', () => {
+    expect(
+      allarmeMezzogiornoAttivo(MEZZOGIORNO_INVERNO, true, stato({ presenzeIncomplete: true, pastiNonConfermati: true }))
+    ).toBe(true);
+  });
+});
+
+describe('descrizioneStatoOperativo', () => {
+  it('stringa vuota se tutto è a posto', () => {
+    expect(descrizioneStatoOperativo(stato())).toBe('');
+  });
+
+  it('menziona solo le presenze se solo quelle mancano', () => {
+    const descrizione = descrizioneStatoOperativo(stato({ presenzeIncomplete: true }));
+    expect(descrizione).toContain('presenze');
+    expect(descrizione).not.toContain('pasti');
+  });
+
+  it('menziona solo i pasti se solo quelli mancano', () => {
+    const descrizione = descrizioneStatoOperativo(stato({ pastiNonConfermati: true }));
+    expect(descrizione).toContain('pasti');
+    expect(descrizione).not.toContain('presenze');
+  });
+
+  it('menziona entrambi se entrambi mancano', () => {
+    const descrizione = descrizioneStatoOperativo(stato({ presenzeIncomplete: true, pastiNonConfermati: true }));
+    expect(descrizione).toContain('presenze');
+    expect(descrizione).toContain('pasti');
+  });
+});

--- a/lib/allarmi.ts
+++ b/lib/allarmi.ts
@@ -1,0 +1,117 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+// Vero se, nel fuso Europe/Rome, sono le 12:00 o più tardi — soglia
+// dell'allarme "presenze/pasti non completati" (specs/07 - allarmi.md).
+// Funzione pura: riceve l'istante da controllare invece di leggere
+// `new Date()` al suo interno, per restare testabile.
+export function dopoMezzogiorno(adesso: Date): boolean {
+  const ora = Number(
+    new Intl.DateTimeFormat('en-GB', { timeZone: 'Europe/Rome', hour: '2-digit', hourCycle: 'h23' }).format(adesso)
+  );
+  return ora >= 12;
+}
+
+export type StatoOperativoGiorno = {
+  // Vero se non ci sono classi/bambini attivi: in quel caso nessuno dei
+  // due controlli seguenti ha senso (nulla da segnare).
+  nessunDatoAtteso: boolean;
+  presenzeIncomplete: boolean;
+  pastiNonConfermati: boolean;
+};
+
+// Vero se scatta l'allarme "presenze/pasti non completati entro
+// mezzogiorno" (specs/07). Funzione pura: chi chiama ha già calcolato
+// se il giorno è attivo (specs/53) e lo stato operativo del giorno
+// (I/O, vedi calcolaStatoOperativoGiorno sotto).
+export function allarmeMezzogiornoAttivo(adesso: Date, giornoAttivo: boolean, stato: StatoOperativoGiorno): boolean {
+  if (!giornoAttivo || stato.nessunDatoAtteso) return false;
+  if (!dopoMezzogiorno(adesso)) return false;
+  return stato.presenzeIncomplete || stato.pastiNonConfermati;
+}
+
+// Descrizione testuale di cosa manca, condivisa tra il banner in
+// dashboard e il corpo dell'email (specs/07), per non scrivere la
+// stessa frase in due posti. Stringa vuota se non manca nulla.
+export function descrizioneStatoOperativo(stato: StatoOperativoGiorno): string {
+  const parti: string[] = [];
+  if (stato.presenzeIncomplete) parti.push('non tutte le presenze sono state segnate');
+  if (stato.pastiNonConfermati) parti.push('i pasti non sono stati comunicati a Rojac');
+  return parti.join(' e ');
+}
+
+// Stato operativo di `data` su TUTTO l'asilo (fa I/O, resta coperta
+// solo da e2e — vedi CLAUDE.md, criterio unit test): richiede una
+// visibilità cross-sezione che un utente normale non ha via RLS, chi
+// chiama deve passare un client con la service_role key (stesso motivo
+// già documentato per il report notturno, specs/52).
+export async function calcolaStatoOperativoGiorno(supabase: SupabaseClient, data: string): Promise<StatoOperativoGiorno> {
+  const { data: sezioni } = await supabase.from('sezioni').select('id').eq('attiva', true);
+  const idSezioni = (sezioni ?? []).map((s) => s.id);
+  if (!idSezioni.length) {
+    return { nessunDatoAtteso: true, presenzeIncomplete: false, pastiNonConfermati: false };
+  }
+
+  const { data: bambini } = await supabase.from('bambini').select('id').eq('attiva', true).in('sezione_id', idSezioni);
+  const idBambini = (bambini ?? []).map((b) => b.id);
+  if (!idBambini.length) {
+    return { nessunDatoAtteso: true, presenzeIncomplete: false, pastiNonConfermati: false };
+  }
+
+  const [{ data: presenze }, { data: comunicazione }] = await Promise.all([
+    supabase.from('presenze').select('bambino_id').eq('data', data).in('bambino_id', idBambini),
+    supabase.from('pasti_comunicati').select('id').eq('data', data).maybeSingle(),
+  ]);
+
+  const segnati = new Set((presenze ?? []).map((p) => p.bambino_id));
+  const presenzeIncomplete = idBambini.some((id) => !segnati.has(id));
+
+  return { nessunDatoAtteso: false, presenzeIncomplete, pastiNonConfermati: !comunicazione };
+}
+
+// Vero se `utenteId` ha già confermato la settimana che inizia
+// `settimanaInizio` (fa I/O). Usa la sessione normale dell'utente: la
+// RLS esistente (ore_lavoro_settimane_select_own_or_admin, specs/18)
+// già permette a chiunque di leggere la propria riga, nessun permesso
+// nuovo necessario — a differenza di calcolaStatoOperativoGiorno sopra.
+export async function settimanaPrecedenteConfermata(
+  supabase: SupabaseClient,
+  utenteId: string,
+  settimanaInizio: string
+): Promise<boolean> {
+  const { data } = await supabase
+    .from('ore_lavoro_settimane')
+    .select('id')
+    .eq('utente_id', utenteId)
+    .eq('settimana_inizio', settimanaInizio)
+    .maybeSingle();
+  return !!data;
+}
+
+export type UtenteSettimanaNonConfermata = { utenteId: string; nome: string; cognome: string; email: string };
+
+// Tutti gli utenti abilitati al report ore la cui settimana
+// `settimanaInizio` non risulta confermata (fa I/O) — usata solo dal
+// cron (specs/07): richiede di leggere tutti gli utenti abilitati,
+// serve un client con la service_role key.
+export async function utentiConSettimanaNonConfermata(
+  supabase: SupabaseClient,
+  settimanaInizio: string
+): Promise<UtenteSettimanaNonConfermata[]> {
+  const { data: abilitati } = await supabase
+    .from('profili')
+    .select('id, nome, cognome, email')
+    .eq('abilitato_ore_lavoro', true);
+  if (!abilitati?.length) return [];
+
+  const idUtenti = abilitati.map((u) => u.id);
+  const { data: confermate } = await supabase
+    .from('ore_lavoro_settimane')
+    .select('utente_id')
+    .eq('settimana_inizio', settimanaInizio)
+    .in('utente_id', idUtenti);
+  const confermati = new Set((confermate ?? []).map((c) => c.utente_id));
+
+  return abilitati
+    .filter((u) => !confermati.has(u.id))
+    .map((u) => ({ utenteId: u.id, nome: u.nome, cognome: u.cognome, email: u.email }));
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -2,6 +2,20 @@ import { createClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
 import { oggi } from '@/lib/date';
 
+// Vero se una richiesta a una route di cron (specs/52 -
+// report-email-automatico.md; specs/07 - allarmi.md) porta il secret
+// giusto in Authorization: Bearer $CRON_SECRET (inviato in automatico da
+// Vercel Cron quando la variabile d'ambiente CRON_SECRET è configurata
+// sul progetto) — senza quella variabile, chiunque può chiamare la
+// route (comportamento pre-esistente, utile in locale). Condivisa tra
+// le route di cron per non duplicare lo stesso controllo in ciascuna
+// (CLAUDE.md, jscpd).
+export function autorizzaCron(request: Request): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return true;
+  return request.headers.get('authorization') === `Bearer ${secret}`;
+}
+
 export type Profilo = {
   nome: string;
   cognome: string;

--- a/lib/date.test.ts
+++ b/lib/date.test.ts
@@ -18,6 +18,7 @@ import {
   meseSuccessivo,
   oggi,
   primoGiornoMese,
+  settimanaPrecedente,
   sommaGiorni,
   ultimoGiornoMese,
 } from './date';
@@ -136,6 +137,22 @@ describe('lunediSettimana / domenicaSettimana', () => {
   it('gestisce una settimana a cavallo tra due mesi', () => {
     expect(lunediSettimana('2026-09-01')).toBe('2026-08-31');
     expect(domenicaSettimana('2026-08-31')).toBe('2026-09-06');
+  });
+});
+
+describe('settimanaPrecedente', () => {
+  it('restituisce lunedì-domenica della settimana immediatamente precedente', () => {
+    // 2026-08-20 è un giovedì della settimana 17-23 agosto; la
+    // precedente è 10-16 agosto.
+    expect(settimanaPrecedente('2026-08-20')).toEqual({ inizio: '2026-08-10', fine: '2026-08-16' });
+  });
+
+  it('funziona anche partendo da un lunedì', () => {
+    expect(settimanaPrecedente('2026-08-17')).toEqual({ inizio: '2026-08-10', fine: '2026-08-16' });
+  });
+
+  it('gestisce un cambio di mese', () => {
+    expect(settimanaPrecedente('2026-09-02')).toEqual({ inizio: '2026-08-24', fine: '2026-08-30' });
   });
 });
 

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -73,6 +73,15 @@ export function domenicaSettimana(data: string): string {
   return sommaGiorni(lunediSettimana(data), 6);
 }
 
+// Intervallo (lunedì-domenica) della settimana immediatamente precedente
+// a quella che contiene `data` — usata dall'allarme "settimana ore di
+// lavoro non confermata" (specs/07 - allarmi.md) per sapere quale
+// settimana controllare rispetto a oggi.
+export function settimanaPrecedente(data: string): { inizio: string; fine: string } {
+  const inizio = sommaGiorni(lunediSettimana(data), -7);
+  return { inizio, fine: sommaGiorni(inizio, 6) };
+}
+
 export function formattaIntervalloItaliano(inizio: string, fine: string): string {
   const formatta = (data: string) => {
     const [anno, mese, giorno] = data.split('-').map(Number);

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -8,6 +8,15 @@ export type AllegatoEmail = {
   content: Uint8Array;
 };
 
+const DESTINATARIO_NOTIFICHE_DEFAULT = 'info@asilosartorio.it';
+
+// Indirizzo per tutte le notifiche email automatiche dell'asilo (report
+// notturno, specs/52; allarmi, specs/07): stessa variabile d'ambiente e
+// stesso default per tutte, un solo posto da cambiare.
+export function destinatarioNotifiche(): string {
+  return process.env.REPORT_EMAIL_DESTINATARIO || DESTINATARIO_NOTIFICHE_DEFAULT;
+}
+
 export async function inviaEmail({
   a,
   oggetto,

--- a/lib/versione.ts
+++ b/lib/versione.ts
@@ -4,5 +4,5 @@
 // ora, minuti e secondi (fuso Europe/Rome, non UTC — coerente con
 // lib/date.ts), non solo la data: utile per distinguere più rilasci
 // fatti nello stesso giorno.
-export const VERSIONE_APP = '0.16.0';
-export const DATA_BUILD = '2026-08-31 19:30:17';
+export const VERSIONE_APP = '0.17.0';
+export const DATA_BUILD = '2026-08-31 23:21:54';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "girasole",
-  "version": "0.15.1",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "girasole",
-      "version": "0.15.1",
+      "version": "0.17.0",
       "dependencies": {
         "@supabase/ssr": "^0.5.1",
         "@supabase/supabase-js": "^2.45.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "girasole",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/specs/00 - overview.md
+++ b/specs/00 - overview.md
@@ -40,6 +40,9 @@ della maestra, `5x` amministrazione.
 - [06 - controllo-consistenza.md](06%20-%20controllo-consistenza.md) —
   warning quando presenza/pasto/pre-asilo/post-asilo di un bambino sono
   incoerenti fra loro, in Presenze, Pasti, Report e report email
+- [07 - allarmi.md](07%20-%20allarmi.md) — banner in dashboard ed email
+  automatiche per presenze/pasti non completati entro mezzogiorno e per
+  settimane di ore di lavoro non confermate
 - [11 - login.md](11%20-%20login.md) — login e schermata di login
 - [12 - dashboard-maestre.md](12%20-%20dashboard-maestre.md) — dashboard
   maestra: lista bambini della sezione con stato presenza/pasto del

--- a/specs/07 - allarmi.md
+++ b/specs/07 - allarmi.md
@@ -1,0 +1,145 @@
+# 07 — Allarmi
+
+## Attori
+Tutto lo staff (admin, maestra, assistente) vede gli allarmi in
+dashboard. Nessun utente umano avvia i controlli: un job pianificato
+(Vercel Cron) li valuta e invia le email, come in
+[52 - report-email-automatico.md](52%20-%20report-email-automatico.md).
+Destinatario delle email: una casella email dello staff (di default
+`info@asilosartorio.it`, stessa variabile d'ambiente
+`REPORT_EMAIL_DESTINATARIO` di specs/52), non un utente dell'app.
+
+## Obiettivo
+Segnalare tempestivamente due situazioni anomale che altrimenti
+passerebbero inosservate finché qualcuno non se ne accorge da solo:
+presenze/pasti dimenticati durante la giornata, e una settimana di ore
+di lavoro mai confermata dal personale. Ogni allarme ha due canali,
+sempre entrambi: un banner in dashboard (finché la situazione resta
+anomala) e un'email inviata una sola volta per occorrenza (giorno per
+il primo allarme, utente+settimana per il secondo).
+
+## Scenario: presenze/pasti non completati entro mezzogiorno — banner
+Dato che sono autenticata come admin, maestra o assistente
+E oggi è un giorno attivo (non chiuso, vedi
+[53 - calendario-scolastico.md](53%20-%20calendario-scolastico.md))
+E sono le 12:00 (fuso Europe/Rome) o più tardi
+E almeno un bambino attivo non ha ancora una presenza segnata per oggi,
+oppure i pasti di oggi non sono ancora stati comunicati a Rojac (vedi
+[16 - comunicazione-pasti-rojac.md](16%20-%20comunicazione-pasti-rojac.md))
+Quando apro la dashboard
+Allora vedo un banner di allarme che segnala cosa manca (presenze,
+pasti, o entrambi)
+E lo stesso banner lo vede qualunque altro membro dello staff, non solo
+chi segue quella classe: è una situazione dell'intero asilo, non di una
+singola sezione
+
+## Scenario: nessun banner se tutto è a posto o non è ancora mezzogiorno
+Quando apro la dashboard prima delle 12:00, oppure dopo le 12:00 ma con
+presenze di tutti i bambini attivi già segnate e pasti già comunicati,
+oppure in un giorno di chiusura scolastica
+Allora non vedo il banner di allarme presenze/pasti
+
+## Scenario: presenze/pasti non completati entro mezzogiorno — email
+Dato che, per il giorno appena valutato, presenze e/o pasti non
+risultano completati dopo le 12:00
+Quando il job pianificato gira
+Allora viene inviata una email all'indirizzo configurato, che elenca
+cosa manca
+E se il job gira di nuovo lo stesso giorno, l'email non viene inviata
+una seconda volta (idempotenza per giorno)
+
+## Scenario: settimana di ore di lavoro non confermata — banner
+Dato che sono abilitata al report ore (vedi
+[17 - ore-di-lavoro.md](17%20-%20ore-di-lavoro.md))
+E la settimana scorsa (lunedì-domenica) non risulta confermata (vedi
+[18 - report-ore-lavoro.md](18%20-%20report-ore-lavoro.md))
+Quando apro la dashboard
+Allora vedo un banner personale che mi avvisa della dimenticanza, con
+l'intervallo di date della settimana scorsa
+E questo banner lo vedo solo io, non gli altri membri dello staff: è una
+mia dimenticanza, non un problema dell'intero asilo
+
+## Scenario: nessun banner se la settimana scorsa è già confermata o non sono abilitata
+Quando apro la dashboard e la settimana scorsa risulta già confermata,
+oppure il mio profilo non è abilitato al report ore
+Allora non vedo il banner "settimana non confermata"
+
+## Scenario: settimana di ore di lavoro non confermata — email
+Dato che, per un utente abilitato al report ore, la settimana appena
+conclusa non risulta confermata
+Quando il job pianificato gira
+Allora viene inviata una email all'indirizzo configurato, che indica
+quale utente e quale settimana
+E questo vale indipendentemente per ciascun utente abilitato: se più
+persone non hanno confermato, ciascuna genera una propria email
+E se il job gira di nuovo per la stessa settimana e lo stesso utente,
+l'email non viene inviata una seconda volta (idempotenza per
+utente+settimana) — anche se nel frattempo quell'utente ha confermato
+un'altra settimana
+
+## Regole
+- Il banner "presenze/pasti" richiede una visibilità sull'intero asilo
+  (tutte le sezioni, non solo quelle dell'utente che ha aperto la
+  dashboard): calcolato lato server con la service_role key
+  (`lib/supabase/admin.ts`), stesso motivo già documentato per il report
+  notturno (specs/52) — una maestra non avrebbe altrimenti, via RLS, i
+  permessi per vedere le sezioni altrui. Il banner mostra solo un
+  riepilogo aggregato ("non tutte le presenze sono state segnate"), mai
+  il dettaglio di bambini o classi specifiche di sezioni non proprie.
+- "Presenze non complete" = esiste almeno un bambino attivo (in una
+  sezione attiva) senza alcuna riga in `presenze` per oggi — non conta
+  se il bambino risulta assente/malato (quello è comunque "segnato"),
+  solo l'assenza totale di un dato.
+- "Pasti non confermati" = non esiste ancora una riga in
+  `pasti_comunicati` per oggi (specs/16): la comunicazione a Rojac è
+  un'unica cosa al giorno per l'intero asilo, non per classe, stessa
+  definizione già in uso.
+- Se non ci sono bambini attivi (o nessuna sezione attiva), non scatta
+  nessuno dei due controlli: non c'è nulla da segnare.
+- Il banner "settimana ore non confermata" usa invece la sessione
+  normale dell'utente (RLS): un utente legge solo la propria riga di
+  `ore_lavoro_settimane`, già permesso dalla policy esistente
+  (`ore_lavoro_settimane_select_own_or_admin`, specs/18) — nessun nuovo
+  permesso necessario.
+- "Settimana scorsa" è sempre la settimana (lunedì-domenica) immediatamente
+  precedente a quella corrente, ricalcolata ogni giorno rispetto a oggi:
+  il banner resta visibile per tutta la settimana corrente finché quella
+  passata non viene confermata (nessuna funzione per confermarla in
+  ritardo in questa fase, vedi Fuori scope).
+- Idempotenza delle email tracciata in un'unica tabella
+  `allarmi_inviati` (`tipo`, `chiave`, `inviato_at`): `chiave` è la data
+  per l'allarme presenze/pasti, `{utente_id}_{settimana_inizio}` per
+  l'allarme ore di lavoro — stesso principio "esistenza della riga =
+  già inviato" già in uso per i report notturni (specs/52) e la
+  conferma di una settimana ore (specs/18), qui condiviso in una sola
+  tabella con un discriminatore invece di una tabella per tipo, non
+  essendoci altri campi da conservare oltre alla chiave.
+- Il job è protetto dallo stesso meccanismo già in uso per gli altri
+  cron (header `Authorization: Bearer $CRON_SECRET`).
+- Un errore nell'invio non deve marcare l'occorrenza come "inviata": un
+  tentativo successivo deve poter ritentare (stesso principio di
+  specs/52).
+
+## Note di implementazione
+- Nuova route `app/api/cron/allarmi/route.ts`, un solo cron Vercel che
+  valuta entrambi gli allarmi una volta al giorno, dopo mezzogiorno
+  Europe/Rome — non due cron separati, per restare comodamente dentro
+  il limite di Vercel Hobby (2 cron job per progetto, già a 1 con
+  `report-presenze`; vedi `CLAUDE.md`).
+- Il destinatario riusa la stessa variabile d'ambiente
+  `REPORT_EMAIL_DESTINATARIO` di specs/52 (nuovo helper condiviso
+  `lib/email.ts:destinatarioNotifiche`, che sostituisce la funzione
+  locale `destinatarioReport` di `app/api/cron/report-presenze/route.ts`
+  per non duplicare la stessa logica in due file).
+
+## Fuori scope in questa fase
+- Una funzione per confermare in ritardo una settimana di ore passata
+  (il banner personale avvisa, ma non offre ancora un modo per
+  rimediare da qui: la sezione "Ore di lavoro" mostra solo la settimana
+  corrente, vedi specs/18, "Fuori scope").
+- Una vista per l'admin che riepiloghi chi, tra il personale, non ha
+  ancora confermato le settimane passate (oggi visibile solo utente per
+  utente, dal proprio banner personale, o dalle email che l'admin
+  riceve).
+- Altri allarmi (es. un bambino senza presenza per più giorni di fila,
+  ore straordinarie anomale): non richiesti in questa fase.

--- a/supabase/migrations/0027_allarmi.sql
+++ b/supabase/migrations/0027_allarmi.sql
@@ -1,0 +1,27 @@
+-- Girasole — Allarmi (specs/07 - allarmi.md): tabella di idempotenza
+-- per le email dei due allarmi (presenze/pasti non completati entro
+-- mezzogiorno; settimana di ore di lavoro non confermata). Stesso
+-- principio "esistenza della riga = già inviato" già in uso per i
+-- report notturni (0009/specs/52) e la conferma di una settimana ore
+-- (0025/specs/18), qui condiviso in un'unica tabella con un
+-- discriminatore `tipo` invece di una tabella per allarme, non
+-- essendoci altri campi da conservare oltre alla chiave.
+--
+-- Solo il cron (service_role) la usa: nessun utente autenticato legge o
+-- scrive qui, quindi RLS abilitata senza alcuna policy per
+-- `authenticated` (nega tutto di default).
+--
+-- Incolla questo file nel SQL Editor di Supabase (dopo
+-- 0026_ore_lavoro_permesse_giorni_chiusi.sql) ed eseguilo una volta sola.
+
+create table public.allarmi_inviati (
+  id uuid primary key default gen_random_uuid(),
+  tipo text not null check (tipo in ('presenze_pasti_mezzogiorno', 'settimana_ore_non_confermata')),
+  chiave text not null,
+  inviato_at timestamptz not null default now(),
+  unique (tipo, chiave)
+);
+
+alter table public.allarmi_inviati enable row level security;
+
+grant select, insert on public.allarmi_inviati to service_role;

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/report-presenze",
       "schedule": "0 23 * * *"
+    },
+    {
+      "path": "/api/cron/allarmi",
+      "schedule": "30 11 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- **Allarme 1** — se entro le 12:00 (Europe/Rome) di un giorno attivo non sono state segnate tutte le presenze o non sono stati confermati i pasti (comunicazione a Rojac, specs/16), un banner rosso compare in dashboard per **tutto** lo staff (calcolato con la service_role key, serve vedere l'intero asilo — stesso motivo del report notturno, specs/52) ed è inviata un'email a `info@asilosartorio.it`.
- **Allarme 2** — per ogni utente abilitato al report ore (specs/17) la cui settimana scorsa non risulta confermata (specs/18), un banner ambra **personale** compare in dashboard (RLS normale, l'utente legge solo la propria riga) ed è inviata un'email allo stesso indirizzo. Il secondo indirizzo scritto nel messaggio originale conteneva un refuso ("asilosaetoeio.it"): ho usato lo stesso `info@asilosartorio.it`/`REPORT_EMAIL_DESTINATARIO` già in uso.
- Nuova tabella `allarmi_inviati` (`0027_allarmi.sql`) per l'idempotenza delle email — stesso pattern "esistenza della riga = già inviata" già in uso altrove, un'unica tabella con un discriminatore `tipo` invece di una per allarme.
- Nuova route `app/api/cron/allarmi/route.ts`: **un solo** cron aggiuntivo (non due) per restare nel limite di Vercel Hobby (2 cron per progetto — già a 1 con `report-presenze`), pianificato alle `30 11 * * *` UTC (dopo le 12:00 Rome sia in ora solare sia legale).
- `lib/allarmi.ts` (pure + I/O, con unit test) calcola entrambi gli allarmi, riusato sia dal cron sia dai banner. Estratti due helper condivisi per non duplicare logica già presente in `report-presenze/route.ts`: `lib/auth.ts:autorizzaCron` (verifica `CRON_SECRET`) e `lib/email.ts:destinatarioNotifiche`.
- Nuovo `specs/07 - allarmi.md` (in indice su `specs/00`).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx next lint`
- [x] `npx vitest run` (198 test, inclusi i nuovi unit test di `lib/allarmi.test.ts` e `lib/date.ts:settimanaPrecedente`)
- [x] `npx jscpd` (nessun nuovo duplicato — i 3 clone segnalati sono preesistenti; ho estratto `autorizzaCron` proprio per evitarne uno nuovo tra le due route cron)
- [ ] `npx playwright test e2e/07-allarmi.spec.ts` dal tuo ambiente locale (non eseguibile in questo ambiente sandbox). Diversi scenari dipendono dall'ora reale o dallo stato reale dei dati e si saltano da soli quando non verificabili al momento (stessa cautela di `53-calendario-scolastico.spec.ts`) — utile eseguirli più volte in momenti diversi della giornata per coprirli tutti. Include anche i test della route cron (401 senza secret, idempotenza).

## Da fare dopo il merge
1. Applicare `supabase/migrations/0027_allarmi.sql` nel SQL Editor di Supabase (progetto di test e produzione) — senza, il cron e i banner falliscono a leggere/scrivere `allarmi_inviati`.
2. Il nuovo cron in `vercel.json` (`/api/cron/allarmi`) viene registrato automaticamente al prossimo deploy — verifica che il piano Vercel copra 2 cron job (Hobby ne consente 2, ci arriviamo esattamente con questo); un eventuale terzo cron futuro richiederebbe un piano superiore o un ulteriore accorpamento.

---
_Generated by [Claude Code](https://claude.ai/code/session_0165puuH5x8UEN9SYds2KVhF)_