### PR TITLE
Navigazione tra settimane in Ore di lavoro (specs/18)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1392,6 +1392,67 @@ Due bug segnalati dopo l'uso reale di `/admin/maestre`.
       ci arriviamo esattamente con questo); se in futuro serve un terzo
       cron, servirà valutare un piano superiore o accorpare ulteriormente.
 
+## Navigazione tra settimane in "Ore di lavoro" (v0.18.0)
+- [x] Richiesta dell'utente: il personale può navigare nelle settimane
+      lavorative per verificare le ore inserite o per confermare
+      settimane non ancora confermate, mantenendo il vincolo assoluto
+      di non poter mai inserire/vedere ore per una settimana futura.
+- [x] `specs/18 - report-ore-lavoro.md`: 5 nuovi scenari (navigare a
+      una settimana passata, tornare verso quella corrente, impossibile
+      andare oltre, modificare/confermare una settimana passata non
+      confermata, una settimana passata già confermata resta di sola
+      lettura) e nuove Regole sul parametro `?settimana=` e sul vincolo
+      "mai futuro" applicato su più livelli. `specs/07 - allarmi.md`
+      aggiornato: il banner personale ora linka direttamente alla
+      settimana da confermare, invece di rimandare all'admin (Fuori
+      scope rimosso).
+- [x] `lib/oreLavoro.ts:settimanaOreLavoroRichiesta` (nuova, con unit
+      test in `lib/oreLavoro.test.ts`): risolve/clampa la settimana
+      richiesta (query string o campo form) a un lunedì valido non
+      futuro, altrimenti quella corrente — stessa idea di
+      `lib/report.ts:risolviPeriodoReport` per `?periodo=`. Unica fonte
+      di verità, riusata sia da `app/dashboard/ore-lavoro/page.tsx` (per
+      il parametro `?settimana=`) sia da
+      `app/dashboard/ore-lavoro/actions.ts` (per validare il campo
+      nascosto `settimana_inizio` inviato dal form), per non duplicare
+      lo stesso controllo in due punti (CLAUDE.md, jscpd).
+- [x] `app/dashboard/ore-lavoro/page.tsx`: box di navigazione ambra
+      (stesso stile del periodo in Report) con "←"/etichetta
+      intervallo/"→" — il pulsante "→" non è mai mostrato sulla
+      settimana corrente. Tutto il resto della pagina (sola lettura se
+      confermata, form editabile altrimenti, totali) resta
+      parametrizzato dal lunedì risolto, invariato nella logica.
+- [x] `app/dashboard/ore-lavoro/actions.ts`: `salvaSettimanaOreLavoro` e
+      `confermaSettimanaOreLavoro` accettano qualunque settimana passata
+      valida oltre a quella corrente, rifiutano esplicitamente una
+      settimana futura (messaggi "Non puoi modificare/confermare una
+      settimana futura.").
+- [x] `app/dashboard/page.tsx`: il banner "settimana ore non
+      confermata" (specs/07) ora linka direttamente a
+      `/dashboard/ore-lavoro?settimana=...` invece di invitare a
+      contattare l'admin.
+- [x] `supabase/migrations/0028_ore_lavoro_navigazione_settimane.sql`:
+      due trigger (`ore_lavoro_giorni`, `ore_lavoro_settimane`) che
+      rifiutano a livello database qualunque riga con data/settimana
+      futura, per qualunque ruolo — ultimo livello di difesa oltre a UI
+      e server action, coerente con le altre regole di integrità del
+      progetto.
+- [x] `e2e/18-report-ore-lavoro.spec.ts`: estesa la sequenza esistente
+      con i 5 nuovi scenari (← verso il passato, → verso il presente,
+      assenza di "→"/clamp di un `?settimana=` futuro via URL diretto,
+      modifica/conferma di una settimana passata non confermata —
+      ripristinata al valore trovato, mai confermata per davvero — e il
+      caso di sola lettura se già confermata, che si attiva da solo).
+      `e2e/07-allarmi.spec.ts`: verifica che il link del banner
+      personale punti a `/dashboard/ore-lavoro?settimana=...`.
+- [x] Verificato: `npx tsc --noEmit`, `npx next lint`, `npx vitest run`
+      (205 test) e `npx jscpd` (3 clone preesistenti, sotto soglia,
+      nessuno nuovo) puliti.
+- [ ] **Da fare da parte tua**: applica
+      `supabase/migrations/0028_ore_lavoro_navigazione_settimane.sql`
+      nel SQL Editor di Supabase (test e produzione). Nessuna modifica
+      lato Vercel richiesta da questa feature.
+
 ## Backlog — Fase 2/3
 - [ ] Rette mensili e stato pagamento
 - [ ] Portale genitori (UI dedicata)

--- a/app/dashboard/ore-lavoro/actions.ts
+++ b/app/dashboard/ore-lavoro/actions.ts
@@ -3,31 +3,33 @@
 import { revalidatePath } from 'next/cache';
 import { requireStaff, assicuraAccessoOreLavoro } from '@/lib/auth';
 import { oggi, giorniSettimana } from '@/lib/date';
-import { validaGiornoOreLavoro, oreOrdinariePreviste } from '@/lib/oreLavoro';
+import { validaGiornoOreLavoro, oreOrdinariePreviste, settimanaOreLavoroRichiesta } from '@/lib/oreLavoro';
 import { recuperaProfiloOrario } from '@/lib/profiliOrari';
 import type { EsitoAzione } from '@/components/FormConEsito';
 
-// Nessuna navigazione tra settimane in questa fase (specs/18 -
-// report-ore-lavoro.md, "Fuori scope"): entrambe le azioni scrivono
-// solo sulla settimana corrente, ignorando qualunque valore diverso
-// arrivasse dal campo nascosto settimana_inizio.
-function settimanaCorrenteOSbagliata(formData: FormData): string | null {
-  const settimanaInizio = (formData.get('settimana_inizio') as string) || '';
-  const giorni = giorniSettimana(oggi());
-  return settimanaInizio === giorni[0] ? settimanaInizio : null;
+// Il personale può modificare/confermare qualunque settimana passata,
+// oltre a quella corrente (specs/18) — ma mai una settimana futura:
+// riusa la stessa risoluzione della pagina (settimanaOreLavoroRichiesta)
+// per validare il campo nascosto settimana_inizio inviato dal form,
+// invece di duplicare lo stesso controllo qui.
+function settimanaValidaPerScrittura(formData: FormData): string | null {
+  const richiesta = (formData.get('settimana_inizio') as string) || '';
+  const risolta = settimanaOreLavoroRichiesta(richiesta, oggi());
+  return risolta === richiesta ? richiesta : null;
 }
 
-// Salva le ore/lo stato di ogni giorno della settimana corrente
-// (specs/18): valida PRIMA tutti i giorni inviati (funzione pura,
-// nessun I/O) e scrive solo se sono tutti validi — nessun salvataggio
-// parziale su un errore (specs/05 - feedback.md).
+// Salva le ore/lo stato di ogni giorno della settimana indicata
+// (specs/18: quella corrente o una passata, mai una futura) — valida
+// PRIMA tutti i giorni inviati (funzione pura, nessun I/O) e scrive
+// solo se sono tutti validi: nessun salvataggio parziale su un errore
+// (specs/05 - feedback.md).
 export async function salvaSettimanaOreLavoro(_stato: EsitoAzione, formData: FormData): Promise<EsitoAzione> {
   const { supabase, user, profilo } = await requireStaff({});
   assicuraAccessoOreLavoro(profilo?.abilitato_ore_lavoro);
 
-  const settimanaInizio = settimanaCorrenteOSbagliata(formData);
+  const settimanaInizio = settimanaValidaPerScrittura(formData);
   if (!settimanaInizio) {
-    return { ok: false, messaggio: 'Puoi modificare solo la settimana corrente.' };
+    return { ok: false, messaggio: 'Non puoi modificare una settimana futura.' };
   }
 
   const giorni = giorniSettimana(settimanaInizio);
@@ -75,19 +77,19 @@ export async function salvaSettimanaOreLavoro(_stato: EsitoAzione, formData: For
   return { ok: true };
 }
 
-// Conferma la settimana corrente (specs/18): prima completa con i
-// valori precaricati dal profilo orario ogni giorno non ancora salvato
-// esplicitamente (scenario "confermare la settimana"), poi registra la
-// conferma vera e propria — l'esistenza della riga in
-// ore_lavoro_settimane È la conferma (stesso pattern di
-// report_giornalieri_inviati, specs/52).
+// Conferma la settimana indicata (specs/18: quella corrente o una
+// passata, mai una futura): prima completa con i valori precaricati dal
+// profilo orario ogni giorno non ancora salvato esplicitamente
+// (scenario "confermare la settimana"), poi registra la conferma vera e
+// propria — l'esistenza della riga in ore_lavoro_settimane È la
+// conferma (stesso pattern di report_giornalieri_inviati, specs/52).
 export async function confermaSettimanaOreLavoro(_stato: EsitoAzione, formData: FormData): Promise<EsitoAzione> {
   const { supabase, user, profilo } = await requireStaff({});
   assicuraAccessoOreLavoro(profilo?.abilitato_ore_lavoro);
 
-  const settimanaInizio = settimanaCorrenteOSbagliata(formData);
+  const settimanaInizio = settimanaValidaPerScrittura(formData);
   if (!settimanaInizio) {
-    return { ok: false, messaggio: 'Puoi confermare solo la settimana corrente.' };
+    return { ok: false, messaggio: 'Non puoi confermare una settimana futura.' };
   }
 
   const giorni = giorniSettimana(settimanaInizio);

--- a/app/dashboard/ore-lavoro/page.tsx
+++ b/app/dashboard/ore-lavoro/page.tsx
@@ -1,11 +1,26 @@
+import Link from 'next/link';
 import { NavHeader } from '@/components/NavHeader';
 import { FormConEsito } from '@/components/FormConEsito';
 import { PulsanteInvio } from '@/components/PulsanteInvio';
 import { ConfermaAzione } from '@/components/ConfermaAzione';
 import { RigaOreLavoro, ETICHETTE_STATO_ORE_LAVORO, type StatoGiornoOreLavoro } from '@/components/RigaOreLavoro';
 import { requireStaff, assicuraAccessoOreLavoro } from '@/lib/auth';
-import { oggi, giorniSettimana, giornoSettimanaIso, formattaIntervalloItaliano, formattaDataBreve, formattaDataOraItaliana } from '@/lib/date';
-import { oreOrdinariePreviste, totaliSettimanaOreLavoro, notaGiornoChiusoOreLavoro } from '@/lib/oreLavoro';
+import {
+  oggi,
+  sommaGiorni,
+  giorniSettimana,
+  giornoSettimanaIso,
+  lunediSettimana,
+  formattaIntervalloItaliano,
+  formattaDataBreve,
+  formattaDataOraItaliana,
+} from '@/lib/date';
+import {
+  oreOrdinariePreviste,
+  totaliSettimanaOreLavoro,
+  notaGiornoChiusoOreLavoro,
+  settimanaOreLavoroRichiesta,
+} from '@/lib/oreLavoro';
 import { recuperaProfiloOrario } from '@/lib/profiliOrari';
 import { isGiornoChiuso, chiusurePerPeriodo } from '@/lib/calendarioScolastico';
 import { salvaSettimanaOreLavoro, confermaSettimanaOreLavoro } from './actions';
@@ -23,17 +38,25 @@ const NOMI_GIORNI: Record<number, string> = {
 };
 
 // Sezione "Ore di lavoro" (specs/18 - report-ore-lavoro.md): il
-// personale abilitato (specs/17) registra ore/malattia/assenza per la
-// settimana corrente (tutti i 7 giorni: il personale può lavorare anche
-// nei giorni in cui l'asilo è chiuso, specs/53) e la conferma. Una volta
-// confermata, la pagina mostra i dati in sola lettura.
-export default async function OreLavoroPage() {
+// personale abilitato (specs/17) registra ore/malattia/assenza per una
+// settimana (tutti i 7 giorni: il personale può lavorare anche nei
+// giorni in cui l'asilo è chiuso, specs/53) e la conferma. Può navigare
+// a qualunque settimana passata per rivederla o confermarla, mai a una
+// futura (?settimana=, un lunedì — risolto/clampato da
+// settimanaOreLavoroRichiesta). Una volta confermata, la settimana in
+// questione è mostrata in sola lettura.
+export default async function OreLavoroPage({ searchParams }: { searchParams: { settimana?: string } }) {
   const { supabase, user, profilo, ruolo } = await requireStaff({});
   assicuraAccessoOreLavoro(profilo?.abilitato_ore_lavoro);
 
   const nomeVisualizzato = profilo?.nome || user.email || '';
-  const giorni = giorniSettimana(oggi());
-  const [lunedi, , , , , , domenica] = giorni;
+  const inizioSettimanaCorrente = lunediSettimana(oggi());
+  const lunedi = settimanaOreLavoroRichiesta(searchParams.settimana, oggi());
+  const giorni = giorniSettimana(lunedi);
+  const domenica = giorni[giorni.length - 1];
+  const settimanaPrecedente = sommaGiorni(lunedi, -7);
+  const puoAndareAvanti = lunedi < inizioSettimanaCorrente;
+  const settimanaSuccessiva = sommaGiorni(lunedi, 7);
 
   const [profiloOrario, { data: righeGiorni }, { data: settimana }, chiusure] = await Promise.all([
     recuperaProfiloOrario(supabase, profilo?.profilo_orario_id),
@@ -85,7 +108,26 @@ export default async function OreLavoroPage() {
             ← Torna alla dashboard
           </a>
           <h1 className="mt-2 text-lg font-medium">Ore di lavoro</h1>
-          <p className="mt-1 text-sm text-stone-600">Settimana {formattaIntervalloItaliano(lunedi, domenica)}</p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 rounded-xl border border-amber-200 bg-amber-50 p-3">
+          <Link
+            href={`/dashboard/ore-lavoro?settimana=${settimanaPrecedente}`}
+            aria-label="Settimana precedente"
+            className="rounded-lg border border-amber-300 bg-white px-3 py-2 text-sm font-medium text-amber-900 hover:bg-amber-100"
+          >
+            ←
+          </Link>
+          <span className="text-sm font-medium text-amber-900">{formattaIntervalloItaliano(lunedi, domenica)}</span>
+          {puoAndareAvanti && (
+            <Link
+              href={`/dashboard/ore-lavoro?settimana=${settimanaSuccessiva}`}
+              aria-label="Settimana successiva"
+              className="rounded-lg border border-amber-300 bg-white px-3 py-2 text-sm font-medium text-amber-900 hover:bg-amber-100"
+            >
+              →
+            </Link>
+          )}
         </div>
 
         {confermata && (

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -101,8 +101,10 @@ export default async function DashboardPage({
           <div role="alert" className="rounded-xl border border-amber-300 bg-amber-50 p-4 text-sm text-amber-900">
             <p className="font-semibold">⏰ Non hai confermato le ore della settimana scorsa</p>
             <p className="mt-1">
-              Settimana {formattaIntervalloItaliano(settimanaOreScorsa.inizio, settimanaOreScorsa.fine)}. Contatta
-              l&apos;amministratore per regolarizzarla.
+              Settimana {formattaIntervalloItaliano(settimanaOreScorsa.inizio, settimanaOreScorsa.fine)}.{' '}
+              <Link href={`/dashboard/ore-lavoro?settimana=${settimanaOreScorsa.inizio}`} className="underline">
+                Vai su Ore di lavoro per confermarla.
+              </Link>
             </p>
           </div>
         )}

--- a/e2e/07-allarmi.spec.ts
+++ b/e2e/07-allarmi.spec.ts
@@ -117,6 +117,12 @@ test.describe('07 — Allarmi', () => {
           );
 
           await expect(banner).toBeVisible();
+          // Il banner porta direttamente alla settimana da confermare
+          // (specs/07, specs/18 — navigazione tra settimane).
+          await expect(page.getByRole('link', { name: 'Vai su Ore di lavoro per confermarla.' })).toHaveAttribute(
+            'href',
+            /\/dashboard\/ore-lavoro\?settimana=\d{4}-\d{2}-\d{2}/
+          );
           await nessunaViolazioneA11yGrave(page);
         } finally {
           await page.goto('/admin/maestre');

--- a/e2e/18-report-ore-lavoro.spec.ts
+++ b/e2e/18-report-ore-lavoro.spec.ts
@@ -146,6 +146,65 @@ test.describe('18 — Report ore di lavoro', () => {
         await page.reload();
         await expect(page.getByLabel('Ore ordinarie Sabato')).toHaveValue('3');
 
+        // --- Navigazione tra settimane (specs/18) ---
+
+        // Sulla settimana corrente non c'è alcun modo di andare oltre
+        // (scenario "non è possibile navigare oltre la settimana corrente").
+        await expect(page.getByRole('link', { name: 'Settimana successiva' })).toHaveCount(0);
+
+        // Un indirizzo diretto verso una settimana futura mostra comunque
+        // quella corrente, senza errori (stesso scenario, clamp lato pagina).
+        await page.goto('/dashboard/ore-lavoro?settimana=2099-01-05');
+        await expect(page.getByRole('link', { name: 'Settimana successiva' })).toHaveCount(0);
+        await expect(page.getByLabel('Ore ordinarie Lunedì')).toHaveValue('7');
+
+        // "←" porta alla settimana precedente, con gli stessi dati
+        // (precaricati dal profilo orario dove non ho ancora salvato
+        // nulla per quella settimana) — scenario "navigare a una
+        // settimana passata".
+        await page.goto('/dashboard/ore-lavoro');
+        await page.getByRole('link', { name: 'Settimana precedente' }).click();
+        await page.waitForURL(/settimana=\d{4}-\d{2}-\d{2}/);
+        await expect(page.getByRole('link', { name: 'Settimana successiva' })).toBeVisible();
+        await nessunaViolazioneA11yGrave(page);
+
+        const settimanaPassataConfermata = await page.getByText('Settimana confermata il', { exact: false }).count();
+        if (settimanaPassataConfermata > 0) {
+          // Scenario "una settimana passata già confermata resta di
+          // sola lettura": si attiva da solo se una settimana
+          // precedente risulta già confermata.
+          await expect(page.getByRole('button', { name: 'Salva modifiche' })).toHaveCount(0);
+          await expect(page.getByRole('button', { name: 'Conferma settimana' })).toHaveCount(0);
+        } else {
+          // Scenario "modificare o confermare una settimana passata non
+          // ancora confermata": stesso comportamento della settimana
+          // corrente. Ripristino lo stesso valore trovato, per non
+          // lasciare lo stato diverso da come l'ho trovato.
+          await expect(page.getByLabel('Ore ordinarie Lunedì')).toBeEditable();
+          const valorePrecedente = await page.getByLabel('Ore ordinarie Lunedì').inputValue();
+          await page.getByLabel('Ore ordinarie Lunedì').fill('5');
+          await page.getByRole('button', { name: 'Salva modifiche' }).click();
+          await page.waitForTimeout(1000);
+          await page.reload();
+          await expect(page.getByLabel('Ore ordinarie Lunedì')).toHaveValue('5');
+
+          await page.getByRole('button', { name: 'Conferma settimana' }).click();
+          await expect(
+            page.getByText('Da questo momento non potrai più modificarle', { exact: false })
+          ).toBeVisible();
+          await page.getByRole('button', { name: 'Annulla' }).click();
+
+          await page.getByLabel('Ore ordinarie Lunedì').fill(valorePrecedente);
+          await page.getByRole('button', { name: 'Salva modifiche' }).click();
+          await page.waitForTimeout(1000);
+        }
+
+        // "→" torna verso la settimana corrente (scenario "tornare
+        // verso la settimana corrente"): il pulsante "→" scompare di
+        // nuovo una volta tornati sulla settimana corrente.
+        await page.getByRole('link', { name: 'Settimana successiva' }).click();
+        await expect(page.getByRole('link', { name: 'Settimana successiva' })).toHaveCount(0);
+
         // "Conferma settimana" chiede conferma esplicita: verifico solo
         // che il dialogo compaia e che "Annulla" non confermi nulla (non
         // premo mai "Sì", vedi nota in testa al file).

--- a/lib/oreLavoro.test.ts
+++ b/lib/oreLavoro.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   notaGiornoChiusoOreLavoro,
   oreOrdinariePreviste,
+  settimanaOreLavoroRichiesta,
   totaliSettimanaOreLavoro,
   validaGiornoOreLavoro,
   type InputGiornoOreLavoro,
@@ -192,5 +193,39 @@ describe('notaGiornoChiusoOreLavoro', () => {
     ];
     const nota = notaGiornoChiusoOreLavoro('2026-12-27', chiusure);
     expect(nota).toContain('Vacanze di Natale');
+  });
+});
+
+// 2026-08-31 è un lunedì (settimana corrente per questi test).
+describe('settimanaOreLavoroRichiesta', () => {
+  const OGGI = '2026-08-31';
+
+  it('senza richiesta restituisce la settimana corrente', () => {
+    expect(settimanaOreLavoroRichiesta(undefined, OGGI)).toBe('2026-08-31');
+  });
+
+  it('la settimana corrente richiesta esplicitamente resta invariata', () => {
+    expect(settimanaOreLavoroRichiesta('2026-08-31', OGGI)).toBe('2026-08-31');
+  });
+
+  it('una settimana passata valida viene accettata', () => {
+    expect(settimanaOreLavoroRichiesta('2026-08-24', OGGI)).toBe('2026-08-24');
+  });
+
+  it('una settimana molto passata viene accettata comunque (nessun limite)', () => {
+    expect(settimanaOreLavoroRichiesta('2025-01-06', OGGI)).toBe('2025-01-06');
+  });
+
+  it('una settimana futura viene riportata a quella corrente', () => {
+    expect(settimanaOreLavoroRichiesta('2026-09-07', OGGI)).toBe('2026-08-31');
+  });
+
+  it('una data che non è un lunedì viene riportata alla settimana corrente', () => {
+    expect(settimanaOreLavoroRichiesta('2026-08-25', OGGI)).toBe('2026-08-31'); // martedì
+  });
+
+  it('una stringa non valida viene riportata alla settimana corrente, senza errori', () => {
+    expect(settimanaOreLavoroRichiesta('non-una-data', OGGI)).toBe('2026-08-31');
+    expect(settimanaOreLavoroRichiesta('', OGGI)).toBe('2026-08-31');
   });
 });

--- a/lib/oreLavoro.ts
+++ b/lib/oreLavoro.ts
@@ -1,8 +1,25 @@
-import { formattaDataItaliana, giornoSettimanaIso } from '@/lib/date';
+import { formattaDataItaliana, giornoSettimanaIso, lunediSettimana } from '@/lib/date';
 import { isGiornoChiuso, trovaChiusura, type GiornoChiusura } from '@/lib/calendarioScolastico';
 import type { ProfiloOrario } from '@/lib/profiliOrari';
 
 export type StatoGiornoOreLavoro = 'lavorativo' | 'malattia' | 'assenza';
+
+// Lunedì della settimana da mostrare/modificare in "Ore di lavoro"
+// (specs/18): quello richiesto (query string `?settimana=`, o campo
+// nascosto `settimana_inizio` inviato dal form) se è un lunedì valido e
+// non è nel futuro rispetto a `oggiData`; altrimenti quello della
+// settimana corrente. Mai una settimana futura — vincolo assoluto di
+// specs/18, applicato qui una volta sola e riusato sia dalla pagina
+// (per risolvere il parametro in query string) sia dalle server action
+// (per validare quanto inviato dal form, invece di duplicare lo stesso
+// controllo in due punti — CLAUDE.md, jscpd). Funzione pura.
+export function settimanaOreLavoroRichiesta(richiesta: string | undefined, oggiData: string): string {
+  const inizioCorrente = lunediSettimana(oggiData);
+  if (!richiesta || !/^\d{4}-\d{2}-\d{2}$/.test(richiesta)) return inizioCorrente;
+  if (lunediSettimana(richiesta) !== richiesta) return inizioCorrente;
+  if (richiesta > inizioCorrente) return inizioCorrente;
+  return richiesta;
+}
 
 // Nota puramente informativa per un giorno di chiusura scolastica nel
 // report ore di lavoro (specs/18, specs/53): a differenza del messaggio

--- a/lib/versione.ts
+++ b/lib/versione.ts
@@ -4,5 +4,5 @@
 // ora, minuti e secondi (fuso Europe/Rome, non UTC — coerente con
 // lib/date.ts), non solo la data: utile per distinguere più rilasci
 // fatti nello stesso giorno.
-export const VERSIONE_APP = '0.17.0';
-export const DATA_BUILD = '2026-08-31 23:21:54';
+export const VERSIONE_APP = '0.18.0';
+export const DATA_BUILD = '2026-09-01 23:01:27';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "girasole",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "girasole",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "dependencies": {
         "@supabase/ssr": "^0.5.1",
         "@supabase/supabase-js": "^2.45.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "girasole",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/specs/07 - allarmi.md
+++ b/specs/07 - allarmi.md
@@ -55,7 +55,8 @@ E la settimana scorsa (lunedì-domenica) non risulta confermata (vedi
 [18 - report-ore-lavoro.md](18%20-%20report-ore-lavoro.md))
 Quando apro la dashboard
 Allora vedo un banner personale che mi avvisa della dimenticanza, con
-l'intervallo di date della settimana scorsa
+l'intervallo di date della settimana scorsa e un link che apre
+direttamente quella settimana in "Ore di lavoro" per confermarla
 E questo banner lo vedo solo io, non gli altri membri dello staff: è una
 mia dimenticanza, non un problema dell'intero asilo
 
@@ -104,8 +105,11 @@ un'altra settimana
 - "Settimana scorsa" è sempre la settimana (lunedì-domenica) immediatamente
   precedente a quella corrente, ricalcolata ogni giorno rispetto a oggi:
   il banner resta visibile per tutta la settimana corrente finché quella
-  passata non viene confermata (nessuna funzione per confermarla in
-  ritardo in questa fase, vedi Fuori scope).
+  passata non viene confermata. Il banner punta direttamente a quella
+  settimana in "Ore di lavoro" (`/dashboard/ore-lavoro?settimana=...`,
+  vedi [18 - report-ore-lavoro.md](18%20-%20report-ore-lavoro.md), che
+  permette di navigare e confermare settimane passate), non solo di
+  segnalare il problema.
 - Idempotenza delle email tracciata in un'unica tabella
   `allarmi_inviati` (`tipo`, `chiave`, `inviato_at`): `chiave` è la data
   per l'allarme presenze/pasti, `{utente_id}_{settimana_inizio}` per
@@ -133,10 +137,6 @@ un'altra settimana
   per non duplicare la stessa logica in due file).
 
 ## Fuori scope in questa fase
-- Una funzione per confermare in ritardo una settimana di ore passata
-  (il banner personale avvisa, ma non offre ancora un modo per
-  rimediare da qui: la sezione "Ore di lavoro" mostra solo la settimana
-  corrente, vedi specs/18, "Fuori scope").
 - Una vista per l'admin che riepiloghi chi, tra il personale, non ha
   ancora confermato le settimane passate (oggi visibile solo utente per
   utente, dal proprio banner personale, o dalle email che l'admin

--- a/specs/18 - report-ore-lavoro.md
+++ b/specs/18 - report-ore-lavoro.md
@@ -9,7 +9,11 @@ Dare al personale abilitato un modo per registrare, settimana per
 settimana, le ore di lavoro effettuate — ordinarie e straordinarie — o
 un giorno di malattia/assenza, e per confermare la settimana una volta
 verificata, così da renderla stabile (non più modificabile in autonomia).
-Questo requisito estende
+Il personale può anche navigare tra le settimane passate, per
+rivedere le ore già inserite o per confermare una settimana dimenticata
+(vedi [07 - allarmi.md](07%20-%20allarmi.md), che segnala proprio questo
+caso) — non è invece mai possibile inserire ore per una settimana
+futura. Questo requisito estende
 [17 - ore-di-lavoro.md](17%20-%20ore-di-lavoro.md), che finora abilitava
 solo l'accesso a una sezione placeholder: da qui in poi
 `/dashboard/ore-lavoro` mostra il contenuto vero e proprio.
@@ -96,6 +100,45 @@ malattia/assenza esattamente come per un giorno normale — il personale
 può lavorare (es. pulizie, attività amministrative, formazione) anche
 quando l'asilo non è operativo
 
+## Scenario: navigare a una settimana passata
+Dato che sono su "Ore di lavoro" (settimana corrente)
+Quando premo "←" (settimana precedente)
+Allora vedo la stessa tabella calcolata su quella settimana, con le ore
+già eventualmente salvate, oppure precaricate dal profilo orario se non
+ho ancora salvato nulla per quella settimana
+E posso continuare a premere "←" per risalire a settimane sempre più
+lontane, senza limiti
+
+## Scenario: tornare verso la settimana corrente
+Dato che sto guardando una settimana passata
+Quando premo "→" (settimana successiva)
+Allora vedo la settimana immediatamente successiva, fino a tornare alla
+settimana corrente
+
+## Scenario: non è possibile navigare oltre la settimana corrente
+Dato che sto guardando la settimana corrente
+Quando guardo i controlli di navigazione
+Allora non vedo alcun pulsante "→": non c'è modo di raggiungere una
+settimana futura dall'interfaccia
+E se apro comunque direttamente un indirizzo che punta a una settimana
+futura, vedo la settimana corrente al suo posto (nessun errore, nessuna
+settimana futura mostrata)
+
+## Scenario: modificare o confermare una settimana passata non ancora confermata
+Dato che sto guardando una settimana passata che non ho ancora
+confermato
+Quando modifico le ore di un giorno e premo "Salva modifiche", oppure
+premo "Conferma settimana"
+Allora il comportamento è identico a quello della settimana corrente:
+stesse validazioni, stesso salvataggio, stessa conferma con data/ora
+mostrate a schermo
+
+## Scenario: una settimana passata già confermata resta di sola lettura
+Dato che sto guardando una settimana passata già confermata
+Quando apro "Ore di lavoro" su quella settimana
+Allora vedo i dati in sola lettura, esattamente come per la settimana
+corrente quando è confermata
+
 ## Scenario: accesso negato senza abilitazione
 Dato che il mio profilo non è abilitato al report ore
 Quando provo ad aprire `/dashboard/ore-lavoro`
@@ -137,6 +180,26 @@ Allora vengo reindirizzata alla dashboard (vedi
   di quel submit, nemmeno quelli validi — il personale corregge il
   giorno segnalato e reinvia (stesso pattern "errore ⇒ dati preservati"
   di specs/05 - feedback.md, i campi già compilati restano tali).
+- Navigazione: un parametro in query string (`?settimana=`, un lunedì)
+  indica quale settimana mostrare, di default quella corrente. Ogni
+  settimana passata (confermata o no) si comporta esattamente come la
+  settimana corrente nello stesso stato — stessa UI, stesse regole di
+  salvataggio/conferma — semplicemente riferita a un'altra data.
+- **Vincolo assoluto: non è mai possibile inserire o vedere ore per una
+  settimana futura.** Se il parametro `settimana` non è un lunedì
+  valido, oppure è un lunedì futuro rispetto a oggi (fuso Europe/Rome),
+  la pagina mostra silenziosamente la settimana corrente al suo posto
+  (nessun errore: stesso principio di "parametro non valido ⇒ valore di
+  default" già usato per `?periodo=` nel Report, specs/51). Applicato su
+  più livelli, come per le altre regole di integrità del progetto: il
+  pulsante "→" non è disponibile oltre la settimana corrente, la pagina
+  clampa un parametro fuori range, le server action rifiutano un
+  `settimana_inizio` futuro passato via form, e un trigger sul database
+  (`supabase/migrations/0028_ore_lavoro_navigazione_settimane.sql`)
+  rifiuta comunque qualunque riga con data (o settimana confermata)
+  futura — vale per QUALUNQUE ruolo, admin incluso: non è un permesso di
+  scrittura ma un vincolo di coerenza dei dati (non si possono lavorare
+  ore che non sono ancora accadute).
 
 ## Fuori scope in questa fase
 - Un'interfaccia dedicata per l'admin per rivedere/correggere le
@@ -146,7 +209,5 @@ Allora vengo reindirizzata alla dashboard (vedi
   intervenire dal SQL Editor di Supabase se necessario.
 - Il calcolo effettivo di un monte ore/straordinari a partire dai dati
   registrati, ed eventuali riepiloghi o export.
-- Navigazione tra settimane passate o future: si vede sempre e solo la
-  settimana corrente.
 - "Riaprire" una settimana già confermata (renderla di nuovo
   modificabile dal personale): nessuna azione la offre in questa fase.

--- a/supabase/migrations/0028_ore_lavoro_navigazione_settimane.sql
+++ b/supabase/migrations/0028_ore_lavoro_navigazione_settimane.sql
@@ -1,0 +1,47 @@
+-- Girasole — Navigazione tra le settimane del report ore di lavoro
+-- (specs/18 - report-ore-lavoro.md): il personale può ora rivedere e
+-- confermare settimane passate, non solo quella corrente. Resta però
+-- un vincolo assoluto: non è mai possibile registrare o confermare ore
+-- per una settimana futura, per QUALUNQUE ruolo (admin incluso) — non
+-- è un permesso di scrittura ma un vincolo di coerenza dei dati (non si
+-- possono lavorare ore che non sono ancora accadute). Già applicato in
+-- app (lib/oreLavoro.ts, pagina e server action), qui imposto anche a
+-- livello di database come difesa in profondità, stesso principio già
+-- usato per altri vincoli di integrità del progetto.
+--
+-- Incolla questo file nel SQL Editor di Supabase (dopo
+-- 0027_allarmi.sql) ed eseguilo una volta sola.
+
+create or replace function public.impedisci_ore_lavoro_futura()
+returns trigger
+language plpgsql
+as $$
+begin
+  if new.data > (now() at time zone 'Europe/Rome')::date then
+    raise exception 'Impossibile registrare ore per una data futura: %.', new.data;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists ore_lavoro_giorni_blocca_futuro on public.ore_lavoro_giorni;
+create trigger ore_lavoro_giorni_blocca_futuro
+  before insert or update on public.ore_lavoro_giorni
+  for each row execute procedure public.impedisci_ore_lavoro_futura();
+
+create or replace function public.impedisci_conferma_settimana_futura()
+returns trigger
+language plpgsql
+as $$
+begin
+  if new.settimana_inizio > (now() at time zone 'Europe/Rome')::date then
+    raise exception 'Impossibile confermare una settimana futura: %.', new.settimana_inizio;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists ore_lavoro_settimane_blocca_futuro on public.ore_lavoro_settimane;
+create trigger ore_lavoro_settimane_blocca_futuro
+  before insert on public.ore_lavoro_settimane
+  for each row execute procedure public.impedisci_conferma_settimana_futura();


### PR DESCRIPTION
## Riepilogo
- Il personale può ora navigare tra le settimane lavorative passate in "Ore di lavoro" per verificare le ore già inserite o confermare settimane dimenticate, tramite un box di navigazione (`←`/intervallo/`→`, stesso stile del periodo in Report) parametrizzato dalla query string `?settimana=`.
- Resta un vincolo assoluto: non è mai possibile inserire o vedere ore per una settimana futura. Applicato su più livelli: UI (`→` mai mostrato oltre la settimana corrente), pagina (`lib/oreLavoro.ts:settimanaOreLavoroRichiesta` clampa un `?settimana=` non valido/futuro alla settimana corrente), server action (`salvaSettimanaOreLavoro`/`confermaSettimanaOreLavoro` rifiutano un `settimana_inizio` futuro), e un nuovo trigger database (`supabase/migrations/0028_ore_lavoro_navigazione_settimane.sql`) che rifiuta comunque righe con data/settimana futura per qualunque ruolo, admin incluso.
- Il banner personale "settimana ore non confermata" in dashboard (specs/07) ora linka direttamente alla settimana da confermare, invece di rimandare all'admin.

## Requisiti
- `specs/18 - report-ore-lavoro.md`: 5 nuovi scenari (navigare a una settimana passata, tornare verso quella corrente, impossibile andare oltre, modificare/confermare una settimana passata non confermata, una settimana passata già confermata resta di sola lettura) e nuove Regole sulla navigazione.
- `specs/07 - allarmi.md`: aggiornato di conseguenza (link diretto invece di "contatta l'admin").

## Test
- Unit: nuova `lib/oreLavoro.ts:settimanaOreLavoroRichiesta` con 8 casi in `lib/oreLavoro.test.ts` (settimana corrente/passata/futura/non-lunedì/stringa non valida).
- e2e: estesi `e2e/18-report-ore-lavoro.spec.ts` (i 5 nuovi scenari) ed `e2e/07-allarmi.spec.ts` (link del banner verso la settimana corretta).
- `npx tsc --noEmit`, `npx next lint`, `npx vitest run` (205 test) e `npx jscpd` (3 clone preesistenti, nessuno nuovo) puliti.

## Da fare dopo il merge
- Applicare `supabase/migrations/0028_ore_lavoro_navigazione_settimane.sql` nel SQL Editor di Supabase (progetto test e produzione).
- Nessuna modifica lato Vercel richiesta da questa feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165puuH5x8UEN9SYds2KVhF

---
_Generated by [Claude Code](https://claude.ai/code/session_0165puuH5x8UEN9SYds2KVhF)_