### PR TITLE
Fix: vincolo "mai ore future" bloccava il salvataggio a metà settimana

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1453,6 +1453,47 @@ Due bug segnalati dopo l'uso reale di `/admin/maestre`.
       nel SQL Editor di Supabase (test e produzione). Nessuna modifica
       lato Vercel richiesta da questa feature.
 
+## Bug: impossibile salvare le ore a metà settimana (v0.18.1)
+- [x] Segnalazione dell'utente: dopo aver applicato la migration
+      0028, salvare le ore non andava più a buon fine a metà settimana
+      (es. registrare lunedì/martedì quando oggi è martedì), per il
+      vincolo "mai ore future".
+- [x] Causa: il trigger `impedisci_ore_lavoro_futura` (0028) confrontava
+      `data` del singolo giorno con la data odierna. Il form di
+      "Ore di lavoro" invia però sempre tutti e 7 i giorni della
+      settimana in un solo upsert, quindi qualunque salvataggio prima
+      di domenica includeva anche giorni successivi a oggi (ancora non
+      accaduti, ma dentro la settimana corrente, comunque ammessa) —
+      Postgres rifiutava l'intera istruzione per quelle righe, bloccando
+      di fatto ogni salvataggio che non avvenisse l'ultimo giorno della
+      settimana. Il vincolo di specs/18 è "mai una settimana futura", non
+      "mai un giorno futuro dentro una settimana ammessa".
+- [x] `specs/18 - report-ore-lavoro.md`: nuovo scenario "salvare le ore
+      anche a metà settimana"; chiarita la Regola del vincolo assoluto
+      per esplicitare che riguarda la settimana, non il singolo giorno.
+- [x] `supabase/migrations/0029_fix_ore_lavoro_vincolo_futuro.sql`
+      (nuova — 0028 era già applicata, quindi corretta in avanti anziché
+      modificata): `impedisci_ore_lavoro_futura` ora confronta la
+      settimana (lunedì) di `data` con la settimana corrente
+      (`date_trunc('week', ...)`), non `data` con la data odierna.
+      Nessuna modifica lato applicazione: la logica in `lib/oreLavoro.ts`,
+      nella pagina e nelle server action era già corretta (sempre a
+      livello di settimana).
+- [x] `e2e/18-report-ore-lavoro.spec.ts`: il primo "Salva modifiche" del
+      test principale ora verifica esplicitamente l'assenza di errori,
+      a copertura del nuovo scenario (il form invia comunque tutti i
+      giorni della settimana, inclusi quelli non ancora accaduti, ad
+      ogni salvataggio — prima della fix questo submit falliva se
+      eseguito prima dell'ultimo giorno della settimana).
+- [x] Verificato: `npx tsc --noEmit`, `npx next lint`, `npx vitest run`
+      (205 test) e `npx jscpd` (3 clone preesistenti, nessuno nuovo)
+      puliti.
+- [ ] **Da fare da parte tua**: applica
+      `supabase/migrations/0029_fix_ore_lavoro_vincolo_futuro.sql` nel
+      SQL Editor di Supabase (test e produzione), subito dopo la 0028 se
+      non ancora applicata, o al suo posto se 0028 è già a posto ma con
+      questo bug. Nessuna modifica lato Vercel richiesta.
+
 ## Backlog — Fase 2/3
 - [ ] Rette mensili e stato pagamento
 - [ ] Portale genitori (UI dedicata)

--- a/e2e/18-report-ore-lavoro.spec.ts
+++ b/e2e/18-report-ore-lavoro.spec.ts
@@ -104,9 +104,18 @@ test.describe('18 — Report ore di lavoro', () => {
         await expect(page.getByRole('alert')).toContainText('motivo');
 
         // Con il motivo: accettato, il totale della settimana si aggiorna.
+        // Il form invia sempre tutti e 7 i giorni in un solo
+        // salvataggio: se oggi non è domenica, questo submit include
+        // anche giorni non ancora accaduti della stessa settimana, e
+        // deve comunque andare a buon fine (scenario "salvare le ore
+        // anche a metà settimana" — bug: un trigger sul database
+        // rifiutava erroneamente qualunque giorno futuro anche dentro
+        // la settimana corrente, impedendo di salvare a metà settimana;
+        // vedi supabase/migrations/0029_fix_ore_lavoro_vincolo_futuro.sql).
         await page.getByLabel('Ore straordinarie Lunedì').fill('2');
         await page.getByLabel('Motivo straordinario Lunedì').fill('Riunione E2E');
         await page.getByRole('button', { name: 'Salva modifiche' }).click();
+        await expect(page.getByRole('alert')).toHaveCount(0);
         await expect(page.getByText('2h straordinarie', { exact: false })).toBeVisible({ timeout: 20_000 });
 
         // Malattia senza codice: rifiutata.

--- a/lib/versione.ts
+++ b/lib/versione.ts
@@ -4,5 +4,5 @@
 // ora, minuti e secondi (fuso Europe/Rome, non UTC — coerente con
 // lib/date.ts), non solo la data: utile per distinguere più rilasci
 // fatti nello stesso giorno.
-export const VERSIONE_APP = '0.18.0';
-export const DATA_BUILD = '2026-09-01 23:01:27';
+export const VERSIONE_APP = '0.18.1';
+export const DATA_BUILD = '2026-09-02 11:02:12';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "girasole",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "girasole",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "dependencies": {
         "@supabase/ssr": "^0.5.1",
         "@supabase/supabase-js": "^2.45.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "girasole",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/specs/18 - report-ore-lavoro.md
+++ b/specs/18 - report-ore-lavoro.md
@@ -44,6 +44,18 @@ Allora i valori inseriti sono salvati e restano tali riaprendo la pagina
 E vedo il totale delle ore della settimana (ordinarie + straordinarie)
 aggiornato di conseguenza
 
+## Scenario: salvare le ore anche a metà settimana
+Dato che sono sulla settimana corrente e oggi non è l'ultimo giorno
+della settimana (alcuni giorni successivi non sono ancora accaduti)
+Quando modifico le ore di un giorno già trascorso e premo "Salva
+modifiche"
+Allora il salvataggio va a buon fine — il form invia sempre tutti e 7 i
+giorni della settimana in un solo salvataggio, e i giorni non ancora
+accaduti (con i loro valori precaricati/di default) non fanno fallire
+il salvataggio: il vincolo di "mai una settimana futura" riguarda la
+settimana nel suo complesso, non i singoli giorni non ancora accaduti
+dentro una settimana comunque ammessa
+
 ## Scenario: le ore straordinarie richiedono un motivo
 Quando per un giorno inserisco delle ore straordinarie senza indicarne
 il motivo, e premo "Salva modifiche"
@@ -199,7 +211,17 @@ Allora vengo reindirizzata alla dashboard (vedi
   rifiuta comunque qualunque riga con data (o settimana confermata)
   futura — vale per QUALUNQUE ruolo, admin incluso: non è un permesso di
   scrittura ma un vincolo di coerenza dei dati (non si possono lavorare
-  ore che non sono ancora accadute).
+  ore che non sono ancora accadute). Il vincolo è sulla **settimana**,
+  non sul singolo giorno: dentro una settimana ammessa (corrente o
+  passata) restano scrivibili anche i giorni che non sono ancora
+  accaduti (es. venerdì, quando oggi è lunedì) — il form invia sempre
+  tutti e 7 i giorni in un solo salvataggio, e lo scenario "confermare
+  la settimana" già prevede di registrare con valori precaricati anche i
+  giorni non ancora salvati esplicitamente. Bloccare un giorno futuro
+  dentro una settimana ammessa impedirebbe di salvare qualunque cosa a
+  metà settimana: il trigger sul database confronta perciò la settimana
+  di `data` (il lunedì che la contiene) con la settimana corrente, non
+  `data` stessa con la data odierna.
 
 ## Fuori scope in questa fase
 - Un'interfaccia dedicata per l'admin per rivedere/correggere le

--- a/supabase/migrations/0029_fix_ore_lavoro_vincolo_futuro.sql
+++ b/supabase/migrations/0029_fix_ore_lavoro_vincolo_futuro.sql
@@ -1,0 +1,28 @@
+-- Girasole — Correzione bug in 0028_ore_lavoro_navigazione_settimane.sql
+-- (specs/18 - report-ore-lavoro.md): il trigger su ore_lavoro_giorni
+-- confrontava `data` con la data odierna, bloccando qualunque giorno
+-- futuro all'interno di una settimana comunque ammessa (corrente o
+-- passata) — es. salvare le ore di lunedì/martedì a metà settimana
+-- falliva, perché il form invia sempre tutti e 7 i giorni della
+-- settimana in un solo upsert, e Postgres rifiuta l'intera istruzione
+-- se anche una sola riga (i giorni successivi a oggi) viola il
+-- trigger. Il vincolo di specs/18 è sulla SETTIMANA, non sul singolo
+-- giorno: dentro una settimana ammessa, un giorno non ancora accaduto
+-- (es. venerdì quando oggi è lunedì) resta scrivibile, come già
+-- previsto dallo scenario "confermare la settimana" (che registra con
+-- valori precaricati anche i giorni non ancora salvati esplicitamente).
+--
+-- Incolla questo file nel SQL Editor di Supabase (dopo 0028) ed
+-- eseguilo una volta sola.
+
+create or replace function public.impedisci_ore_lavoro_futura()
+returns trigger
+language plpgsql
+as $$
+begin
+  if date_trunc('week', new.data)::date > date_trunc('week', (now() at time zone 'Europe/Rome')::date)::date then
+    raise exception 'Impossibile registrare ore per una settimana futura: %.', new.data;
+  end if;
+  return new;
+end;
+$$;


### PR DESCRIPTION
## Bug
Dopo aver applicato `supabase/migrations/0028_ore_lavoro_navigazione_settimane.sql`, il personale non riusciva più a salvare le ore a metà settimana (es. registrare le ore di lunedì/martedì quando oggi è martedì).

## Causa
Il trigger `impedisci_ore_lavoro_futura` (0028) confrontava la data del singolo giorno con la data odierna. Il form di "Ore di lavoro" invia però sempre tutti e 7 i giorni della settimana in un solo upsert: qualunque salvataggio effettuato prima di domenica includeva anche giorni successivi a oggi (non ancora accaduti, ma dentro la settimana corrente — comunque ammessa), e Postgres rifiutava l'intera istruzione. Il vincolo di specs/18 ("mai una settimana futura") riguarda la settimana, non il singolo giorno al suo interno.

## Fix
- `supabase/migrations/0029_fix_ore_lavoro_vincolo_futuro.sql` (nuova, dato che 0028 era già applicata): `impedisci_ore_lavoro_futura` ora confronta la settimana (lunedì) di `data` con la settimana corrente (`date_trunc('week', ...)`), non `data` con la data odierna.
- Nessuna modifica lato applicazione: `lib/oreLavoro.ts`, la pagina e le server action erano già corrette (ragionano sempre a livello di settimana).
- `specs/18 - report-ore-lavoro.md`: nuovo scenario "salvare le ore anche a metà settimana", Regola del vincolo assoluto chiarita.
- `e2e/18-report-ore-lavoro.spec.ts`: il primo "Salva modifiche" del test principale ora verifica esplicitamente l'assenza di errori (il submit include comunque tutti i giorni della settimana, inclusi quelli non ancora accaduti).

## Test
- `npx tsc --noEmit`, `npx next lint`, `npx vitest run` (205 test) e `npx jscpd` (3 clone preesistenti, nessuno nuovo) puliti.

## Da fare dopo il merge
- Applicare `supabase/migrations/0029_fix_ore_lavoro_vincolo_futuro.sql` nel SQL Editor di Supabase (test e produzione), subito dopo la 0028.
- Nessuna modifica lato Vercel richiesta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165puuH5x8UEN9SYds2KVhF

---
_Generated by [Claude Code](https://claude.ai/code/session_0165puuH5x8UEN9SYds2KVhF)_